### PR TITLE
#95 positionnement des points sur un plan

### DIFF
--- a/Android/app/src/main/java/fr/uge/structsure/components/Plan.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/components/Plan.kt
@@ -1,0 +1,68 @@
+package fr.uge.structsure.components
+
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.gestures.detectTransformGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import kotlin.reflect.KProperty
+
+@Composable
+fun Plan(@DrawableRes image: Int) {
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(0.dp))
+            .fillMaxWidth()
+            .height(171.dp)
+    ) {
+        // Define mutable state variables to keep track of the scale and offset.
+        var scale by remember { mutableFloatStateOf(1f) }
+        var offset by remember { mutableStateOf(Offset(0f, 0f)) }
+
+        // Create an Image composable with zooming and panning.
+        Image(
+            painter = painterResource(image),
+            contentDescription = "Plan",
+            contentScale = ContentScale.Crop,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(171.dp)
+                .pointerInput(Unit) {
+                    detectTransformGestures { _, pan, zoom, _ ->
+                        // Update the scale based on zoom gestures.
+                        scale *= zoom
+
+                        // Limit the zoom levels within a certain range (optional).
+                        scale = scale.coerceIn(1f, 3f)
+
+                        // Update the offset to implement panning when zoomed.
+                        offset = if (scale == 1f) Offset(0f, 0f) else offset + pan
+                    }
+                }
+                .graphicsLayer(
+                    scaleX = scale, scaleY = scale,
+                    translationX = offset.x, translationY = offset.y
+                )
+        )
+    }
+}
+
+private operator fun Any.getValue(nothing: Nothing?, property: KProperty<*>): Any {
+    TODO("Not yet implemented")
+}

--- a/Android/app/src/main/java/fr/uge/structsure/components/Plan.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/components/Plan.kt
@@ -1,11 +1,15 @@
 package fr.uge.structsure.components
 
+import android.content.res.Resources.getSystem
 import androidx.annotation.DrawableRes
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -13,56 +17,119 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import kotlin.reflect.KProperty
+import fr.uge.structsure.startScan.presentation.components.SensorState
+
+private val Int.toPx: Int get() = (this * getSystem().displayMetrics.density).toInt()
+
+data class Point(val x: Int, val y: Int)
 
 @Composable
 fun Plan(@DrawableRes image: Int) {
+    val points = mutableListOf(Point(100, 100))
+    val imgSize = painterResource(image).intrinsicSize
     Box(
         modifier = Modifier
             .clip(RoundedCornerShape(0.dp))
             .fillMaxWidth()
-            .height(171.dp)
+            .aspectRatio(imgSize.width / imgSize.height),
+        Alignment.Center
     ) {
         // Define mutable state variables to keep track of the scale and offset.
         var scale by remember { mutableFloatStateOf(1f) }
         var offset by remember { mutableStateOf(Offset(0f, 0f)) }
 
-        // Create an Image composable with zooming and panning.
         Image(
-            painter = painterResource(image),
-            contentDescription = "Plan",
-            contentScale = ContentScale.Crop,
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(171.dp)
-                .pointerInput(Unit) {
-                    detectTransformGestures { _, pan, zoom, _ ->
-                        // Update the scale based on zoom gestures.
-                        scale *= zoom
+            painterResource(image),
+            "Plan",
+            Modifier
+                .fillMaxSize()
+                .pointerInput(Unit) { /* Zoom and pane the image*/
+                    detectTransformGestures { centroid, pan, zoom, _ ->
+                        val adjustment = centroid * (1 - zoom)
+                        offset = (offset + pan) * zoom + adjustment
+                        scale = (scale * zoom).coerceIn(1f, 3f)
 
-                        // Limit the zoom levels within a certain range (optional).
-                        scale = scale.coerceIn(1f, 3f)
-
-                        // Update the offset to implement panning when zoomed.
-                        offset = if (scale == 1f) Offset(0f, 0f) else offset + pan
+                        val width = (size.width * scale - size.width)/2
+                        val height = (size.height * scale - size.height)/2f
+                        println("${imgSize.width} - ${imgSize.height}")
+                        println(offset.x)
+                        offset = Offset(
+                            offset.x.coerceIn(-width, width),
+                            offset.y.coerceIn(-height, height)
+                        )
                     }
+                }
+                .pointerInput(Unit) {
+                    detectTapGestures(
+                        onDoubleTap = { /* Double click to zoom in or out */
+                            if (scale >= 1.1f) {
+                                scale = 1f
+                                offset = Offset(0f, 0f)
+                            } else scale = 3f
+                        },
+                        onTap = { pos ->
+                            // TODO on click
+                        }
+                    )
                 }
                 .graphicsLayer(
                     scaleX = scale, scaleY = scale,
                     translationX = offset.x, translationY = offset.y
                 )
         )
+
+        Canvas(Modifier.fillMaxSize()) {
+            points.forEach {
+                val panned = zoomAndPan(offset, scale, size, it.x, it.y)
+                point(size, panned.x, panned.y, SensorState.NOK)
+            }
+        }
     }
 }
 
-private operator fun Any.getValue(nothing: Nothing?, property: KProperty<*>): Any {
-    TODO("Not yet implemented")
+/**
+ * Draw a point representing a sensor on a plan.
+ * @param x the x coordinate of the center of the point
+ * @param y the y coordinate of the center of the point
+ * @param state the state of the sensor to show its color
+ */
+private fun DrawScope.point(size: Size, x: Float, y: Float, state: SensorState) {
+    val visibleX = x + 30 >= 0 && x - 30 <= size.width
+    val visibleY = y + 30 >= 0 && y - 30 <= size.height
+    if (!visibleX || !visibleY) return // out of canvas
+    drawCircle(
+        color = state.color,
+        radius = 20f,
+        center = Offset(x + 0f,  y + 0f),
+    )
+    drawCircle(
+        color = state.color.copy(alpha = 0.25F),
+        radius = 30f,
+        center = Offset(x + 0f, y + 0f),
+    )
+}
+
+/**
+ * Transforms the coordinates of the given point to apply pan and zoom
+ * to it and calculates it new position on the screen.
+ * @param pan values of the horizontal/vertical displacement to apply
+ * @param zoom level of zoom to apply between 1 and 3
+ * @param size the size of the canvas to draw on
+ * @param x the initial x coordinate in the plan without zoom
+ * @param y the initial y coordinate in the plan iwz
+ */
+private fun zoomAndPan(pan: Offset, zoom: Float, size: Size, x: Int, y: Int): Offset {
+    val centerX = size.width / 2f
+    val centerY = size.height / 2f
+    return Offset((x - centerX) * zoom + centerX + pan.x, (y - centerY) * zoom + centerY + pan.y)
 }

--- a/Android/app/src/main/java/fr/uge/structsure/database/AppDatabase.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/database/AppDatabase.kt
@@ -30,7 +30,7 @@ import fr.uge.structsure.structuresPage.data.StructureData
 @Database(
     entities = [ScanEntity::class, StructureEntity::class, AccountEntity::class,
         StructureData::class, SensorDB::class, PlanDB::class],
-    version = 4,
+    version = 5,
     exportSchema = false
 )
 /**

--- a/Android/app/src/main/java/fr/uge/structsure/retrofit/RetrofitInstance.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/retrofit/RetrofitInstance.kt
@@ -18,7 +18,7 @@ import retrofit2.converter.gson.GsonConverterFactory
  */
 object RetrofitInstance {
 
-    private const val BASE_URL = "http://10.42.0.191:8080"
+    private const val BASE_URL = "https://structsure.miumo.xyz"
     private var tokenProvider: () -> String = {
         val account = MainActivity.db.accountDao().get()
         if (account == null) "" else account.token?: ""

--- a/Android/app/src/main/java/fr/uge/structsure/retrofit/StructureApi.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/retrofit/StructureApi.kt
@@ -7,7 +7,7 @@ import retrofit2.http.GET
 import retrofit2.http.Path
 
 interface StructureApi {
-    @GET("api/structures/android")
+    @GET("api/structures")
     fun getAllStructures(): Call<List<GetAllStructureResponse>>
 
     @GET("/api/structures/android/{id}")

--- a/Android/app/src/main/java/fr/uge/structsure/retrofit/response/GetAllStructureResponse.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/retrofit/response/GetAllStructureResponse.kt
@@ -1,11 +1,13 @@
 package fr.uge.structsure.retrofit.response
 
 import com.google.gson.annotations.SerializedName
+import fr.uge.structsure.startScan.presentation.components.SensorState
 
 data class GetAllStructureResponse(
     @SerializedName("id") val id: Long,
     @SerializedName("name") val name: String,
-    @SerializedName("numberOfSensors") val numberOfSensors: Int,
-    @SerializedName("numberOfPlans") val numberOfPlans: Int,
-    @SerializedName("url") val url: String
+    @SerializedName("numberOfSensors") val numberOfSensors: Long,
+    @SerializedName("numberOfPlans") val numberOfPlans: Long,
+    @SerializedName("archived") val archived: Boolean,
+    @SerializedName("state") val state: SensorState,
 )

--- a/Android/app/src/main/java/fr/uge/structsure/startScan/presentation/PlansView.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/startScan/presentation/PlansView.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import fr.uge.structsure.R
+import fr.uge.structsure.components.Plan
 import fr.uge.structsure.ui.theme.Black
 import fr.uge.structsure.ui.theme.LightGray
 import fr.uge.structsure.ui.theme.Typography
@@ -66,14 +67,7 @@ fun PlansView(modifier: Modifier = Modifier) {
             verticalArrangement = Arrangement.spacedBy(15.dp, Alignment.CenterVertically),
             horizontalAlignment = Alignment.Start
         )  {
-            Image(
-                painter = painterResource(id = R.drawable.oa_plan),
-                contentDescription = "Plan",
-                contentScale = ContentScale.Crop,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(171.dp)
-            )
+            Plan(R.drawable.oa_plan)
 
             Spacer( Modifier.fillMaxWidth().height(1.dp).background(LightGray) )
 

--- a/Android/app/src/main/java/fr/uge/structsure/startScan/presentation/PlansView.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/startScan/presentation/PlansView.kt
@@ -67,7 +67,7 @@ fun PlansView(modifier: Modifier = Modifier) {
             verticalArrangement = Arrangement.spacedBy(15.dp, Alignment.CenterVertically),
             horizontalAlignment = Alignment.Start
         )  {
-            Plan(R.drawable.oa_debug)
+            Plan(R.drawable.ob_plan)
 
             Spacer( Modifier.fillMaxWidth().height(1.dp).background(LightGray) )
 

--- a/Android/app/src/main/java/fr/uge/structsure/startScan/presentation/PlansView.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/startScan/presentation/PlansView.kt
@@ -67,7 +67,7 @@ fun PlansView(modifier: Modifier = Modifier) {
             verticalArrangement = Arrangement.spacedBy(15.dp, Alignment.CenterVertically),
             horizontalAlignment = Alignment.Start
         )  {
-            Plan(R.drawable.oa_plan)
+            Plan(R.drawable.oa_debug)
 
             Spacer( Modifier.fillMaxWidth().height(1.dp).background(LightGray) )
 

--- a/Android/app/src/main/java/fr/uge/structsure/startScan/presentation/PlansView.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/startScan/presentation/PlansView.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -35,6 +36,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import fr.uge.structsure.R
 import fr.uge.structsure.components.Plan
+import fr.uge.structsure.components.Point
+import fr.uge.structsure.startScan.presentation.components.SensorState
 import fr.uge.structsure.ui.theme.Black
 import fr.uge.structsure.ui.theme.LightGray
 import fr.uge.structsure.ui.theme.Typography
@@ -67,7 +70,11 @@ fun PlansView(modifier: Modifier = Modifier) {
             verticalArrangement = Arrangement.spacedBy(15.dp, Alignment.CenterVertically),
             horizontalAlignment = Alignment.Start
         )  {
-            Plan(R.drawable.ob_plan)
+            val points = remember { mutableStateListOf(
+                Point(0, 0, SensorState.OK),
+                Point(100, 100, SensorState.OK)
+            ) }
+            Plan(R.drawable.oa_plan, points)
 
             Spacer( Modifier.fillMaxWidth().height(1.dp).background(LightGray) )
 

--- a/Android/app/src/main/java/fr/uge/structsure/startScan/presentation/components/SensorState.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/startScan/presentation/components/SensorState.kt
@@ -10,5 +10,5 @@ enum class SensorState(val color : Color) {
     OK(Ok),
     NOK(Red),
     DEFECTIVE(Gray), // Orange color
-    UNSCAN(Unknown)
+    UNKNOWN(Unknown)
 }

--- a/Android/app/src/main/java/fr/uge/structsure/structuresPage/data/StructureData.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/structuresPage/data/StructureData.kt
@@ -2,6 +2,7 @@ package fr.uge.structsure.structuresPage.data
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import fr.uge.structsure.startScan.presentation.components.SensorState
 
 @Entity(tableName = "structure")
 data class StructureData(
@@ -9,10 +10,9 @@ data class StructureData(
     val id: Long = 0,
 
     val name: String,
-    val numberOfSensors: Int,
-    val numberOfPlan: Int,
-    val url: String,
-    var state: Boolean,
-    var fileLocation: String
-
+    val numberOfSensors: Long,
+    val numberOfPlan: Long,
+    var state: SensorState,
+    val archived: Boolean,
+    var downloaded: Boolean
 )

--- a/Android/app/src/main/java/fr/uge/structsure/structuresPage/data/StructureRepository.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/structuresPage/data/StructureRepository.kt
@@ -1,18 +1,13 @@
 package fr.uge.structsure.structuresPage.data
 
-import android.content.Context
 import android.util.Log
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import fr.uge.structsure.retrofit.RetrofitInstance
 import fr.uge.structsure.retrofit.StructureApi
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.io.File
-import java.io.FileOutputStream
-import java.io.OutputStreamWriter
 import java.util.Optional
 
 class StructureRepository(
@@ -39,9 +34,9 @@ class StructureRepository(
                             it.name,
                             it.numberOfPlans,
                             it.numberOfSensors,
-                            it.url,
-                            false,
-                            ""
+                            it.state,
+                            it.archived,
+                            downloaded = false
                         )
                     }
                 } else {
@@ -123,7 +118,7 @@ class StructureRepository(
                 }
             }
         }
-        structure.state = true
+        structure.downloaded = true
         structureDao.upsertStructure(structure)
     }
 

--- a/Android/app/src/main/java/fr/uge/structsure/structuresPage/presentation/components/StructuresListView.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/structuresPage/presentation/components/StructuresListView.kt
@@ -48,7 +48,7 @@ fun StructuresListView(structureViewModel: StructureViewModel, navController: Na
         )
         SearchBar(input = searchByName)
         structures.value?.filter { it.name.contains(searchByName.value) }?.forEach {
-            val state = mutableStateOf(StateMapper(it.state))
+            val state = mutableStateOf(StateMapper(it.downloaded))
             Structure(it, state, structureViewModel, navController)
         }
     }

--- a/Android/app/src/main/java/fr/uge/structsure/structuresPage/presentation/components/StructuresListView.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/structuresPage/presentation/components/StructuresListView.kt
@@ -6,12 +6,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
@@ -27,8 +24,6 @@ private fun StateMapper(state: Boolean): StructureStates {
 
 @Composable
 fun StructuresListView(structureViewModel: StructureViewModel, navController: NavController) {
-    val coroutineScope = rememberCoroutineScope()
-    val latestStructure by rememberUpdatedState(structureViewModel)
     val structures = structureViewModel.getAllStructures.observeAsState()
 
     LaunchedEffect(structureViewModel) {

--- a/Android/app/src/main/java/fr/uge/structsure/structuresPage/presentation/components/StructuresListView.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/structuresPage/presentation/components/StructuresListView.kt
@@ -5,10 +5,13 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
@@ -24,8 +27,13 @@ private fun StateMapper(state: Boolean): StructureStates {
 
 @Composable
 fun StructuresListView(structureViewModel: StructureViewModel, navController: NavController) {
+    val coroutineScope = rememberCoroutineScope()
+    val latestStructure by rememberUpdatedState(structureViewModel)
     val structures = structureViewModel.getAllStructures.observeAsState()
-    structureViewModel.getAllStructures()
+
+    LaunchedEffect(structureViewModel) {
+        structureViewModel.getAllStructures()
+    }
 
     val searchByName = remember { mutableStateOf("") }
 


### PR DESCRIPTION
Visualisation des points sur un plan zoomable de glissable.
J'ai implémenté le clic sur un point (qui le fait changer d'état pour l'instant, histoire de visualiser quelque chose), le clic en dehors d'un point qui créé un nouveau point et l'appuie prolongé sur un point qui le supprime.

Pour tester le comportement de différentes images, voici deux assets qui peuvent être chargés :
![oa_debug](https://github.com/user-attachments/assets/0b62d15b-e953-4e13-89d7-6789127607ac)
Ajoute des repères pour bien voir les angles de l'image ainsi qu'une croix aux coordonnées 100:100 pour contrôler le positionnement des points.

![ob_plan](https://github.com/user-attachments/assets/b19ca99a-759d-4b08-ac63-7ed2487e1266)
Même chose que OA-DEBUG mais en portrait
