### PR TITLE
#93 gestion du ble non initialise

### DIFF
--- a/Android/app/src/main/java/fr/uge/structsure/bluetooth/cs108/Cs108Scanner.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/bluetooth/cs108/Cs108Scanner.kt
@@ -2,7 +2,6 @@ package fr.uge.structsure.bluetooth.cs108
 
 import com.csl.cslibrary4a.RfidReaderChipData
 import fr.uge.structsure.MainActivity
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
@@ -64,7 +63,7 @@ class Cs108Scanner(private val callback: (RfidChip) -> Unit) {
                     ensureActive()
                     val event = MainActivity.csLibrary4A.onRFIDEvent()
                     if (event != null) {
-                        callback(RfidChip(event))
+                        callback(RfidChip(MainActivity.csLibrary4A, event))
                     } else {
                         delay(100L)
                     }

--- a/Android/app/src/main/java/fr/uge/structsure/bluetooth/cs108/RfidChip.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/bluetooth/cs108/RfidChip.kt
@@ -1,7 +1,7 @@
 package fr.uge.structsure.bluetooth.cs108
 
+import com.csl.cslibrary4a.Cs108Library4A
 import com.csl.cslibrary4a.RfidReaderChipData
-import fr.uge.structsure.MainActivity
 
 /**
  * Represent a RFID chip read by a scanner.
@@ -12,10 +12,11 @@ data class RfidChip(val id: String, val attenuation: Int) {
     /**
      * Converts the given Rx00pkgData (raw data from the CS108Lib) to
      * a RfidChip.
+     * @param csLibrary4A access to the library to convert the data
      * @param data the non-null data read by the scanner
      */
-    constructor(data: RfidReaderChipData.Rx000pkgData): this(
-        MainActivity.csLibrary4A.byteArrayToString(data.decodedEpc),
-        (data.decodedRssi - MainActivity.csLibrary4A.dBuV_dBm_constant).toInt()
+    constructor(csLibrary4A: Cs108Library4A, data: RfidReaderChipData.Rx000pkgData): this(
+        csLibrary4A.byteArrayToString(data.decodedEpc),
+        (data.decodedRssi - csLibrary4A.dBuV_dBm_constant).toInt()
     )
 }

--- a/Android/app/src/main/java/fr/uge/structsure/components/BluetoothButton.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/components/BluetoothButton.kt
@@ -29,7 +29,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
-import fr.uge.structsure.MainActivity.Companion.csLibrary4A
 import fr.uge.structsure.R
 import fr.uge.structsure.bluetooth.cs108.Cs108Connector
 import fr.uge.structsure.bluetooth.presentation.BluetoothPage
@@ -45,7 +44,7 @@ import fr.uge.structsure.ui.theme.White
  */
 @Composable
 fun BluetoothButton(connexion: Cs108Connector) {
-    val isBluetoothConnected = csLibrary4A.isBleConnected
+    val isBluetoothConnected = Cs108Connector.isConnected
 
     var batteryLevel by remember { mutableIntStateOf(Cs108Connector.battery) }
     var showPopUp by remember { mutableStateOf(false) }

--- a/Android/app/src/main/java/fr/uge/structsure/scanPage/domain/ScanViewModel.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/scanPage/domain/ScanViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import fr.uge.structsure.MainActivity.Companion.db
+import fr.uge.structsure.bluetooth.cs108.Cs108Connector
 import fr.uge.structsure.bluetooth.cs108.Cs108Scanner
 import fr.uge.structsure.scanPage.data.ResultSensors
 import fr.uge.structsure.scanPage.data.ScanEntity
@@ -217,6 +218,10 @@ class ScanViewModel: ViewModel() {
      * @param structureId ID of the structure to scan.
      */
     fun createNewScan(structureId: Long) {
+        if (!Cs108Connector.isReady) {
+            sensorMessages.postValue("Interrogateur non connecté")
+            return
+        }
         cs108Scanner.start()
         currentScanState.postValue(ScanState.STARTED)
         alertMessages.postValue(null)


### PR DESCRIPTION
Empêche de faire crash l'app quand on lance un scan sans être connecté à l'interrogateur