### PR TITLE
#159 modale de capteur statique

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,4 @@
 Backend/files
 **/structsure-test.db
 **/coverage
+Android/.kotlin

--- a/Android/app/src/main/java/fr/uge/structsure/alertes/Alertes.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/alertes/Alertes.kt
@@ -5,11 +5,9 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
@@ -28,6 +26,7 @@ import androidx.navigation.NavController
 import fr.uge.structsure.R
 import fr.uge.structsure.components.ButtonText
 import fr.uge.structsure.components.Page
+import fr.uge.structsure.components.SensorDetails
 import fr.uge.structsure.ui.theme.Red
 import fr.uge.structsure.ui.theme.White
 
@@ -98,7 +97,7 @@ private fun AlertDetails(state: Boolean, sensorName: String, lastStateSensor: St
             style = MaterialTheme.typography.titleLarge
         )
 
-        SensorDetails(sensorName, lastStateSensor)
+        SensorDetails(White, "Nom du capteur :", sensorName, "Dernier état :", lastStateSensor)
 
         Plan()
 
@@ -109,46 +108,6 @@ private fun AlertDetails(state: Boolean, sensorName: String, lastStateSensor: St
             style = MaterialTheme.typography.bodyMedium,
             textAlign = TextAlign.Center,
             color = White,
-        )
-    }
-}
-
-/**
- * Row displaying the name of the sensor and the last known state.
- * @param name the custom name of the sensor
- * @param state the last saved state of the sensor (NOK, OK, ...)
- */
-@Composable
-private fun SensorDetails(name: String, state: String) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(25.dp, Alignment.CenterHorizontally)
-    ) {
-        SensorDetail("Nom du capteur :", name)
-        SensorDetail("Dernier état :", state)
-    }
-}
-
-/**
- * Displays the details of one attribute of a sensor (name of state).
- * @param title the name of the attribute to display
- * @param value the value
- */
-@Composable
-private fun SensorDetail(title: String, value: String) {
-    Column (
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        Text(
-            modifier = Modifier.alpha(0.5f),
-            text = title,
-            color = White,
-            style = MaterialTheme.typography.bodySmall
-        )
-        Text(
-            text = value,
-            color = White,
-            style = MaterialTheme.typography.headlineMedium
         )
     }
 }

--- a/Android/app/src/main/java/fr/uge/structsure/bluetooth/presentation/BluetoothPage.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/bluetooth/presentation/BluetoothPage.kt
@@ -30,6 +30,7 @@ import com.csl.cslibrary4a.ReaderDevice
 import fr.uge.structsure.R
 import fr.uge.structsure.bluetooth.cs108.Cs108Connector
 import fr.uge.structsure.components.Button
+import fr.uge.structsure.components.Title
 import fr.uge.structsure.ui.theme.White
 
 @Composable
@@ -72,12 +73,7 @@ fun BluetoothPage(bleConnexion: Cs108Connector, onClose: () -> Unit) {
  */
 @Composable
 private fun PaneHeader(onClick: () -> Unit) {
-    Row( // Title
-        Modifier.padding(start = 20.dp)
-    ) {
-        Text("Appairage",
-            style = MaterialTheme.typography.titleLarge,
-            modifier= Modifier.fillMaxWidth().weight(2f))
+    Title("Appairage") {
         Button(R.drawable.x, "close", MaterialTheme.colorScheme.onSurface, MaterialTheme.colorScheme.surface, onClick)
     }
 }

--- a/Android/app/src/main/java/fr/uge/structsure/components/Containers.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/components/Containers.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
@@ -20,9 +21,13 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import fr.uge.structsure.R
 import fr.uge.structsure.ui.theme.Black
 import fr.uge.structsure.ui.theme.White
@@ -44,9 +49,10 @@ fun ContainersPreview() {
 @Composable
 fun Title (
     text: String,
+    indent: Boolean = true,
     content: @Composable () -> Unit = {}
 ) {
-    Row(Modifier.padding(start = 20.dp)) {
+    Row(Modifier.padding(start = if (indent) 20.dp else 0.dp)) {
         Text(text,
             style = MaterialTheme.typography.titleLarge,
             modifier= Modifier
@@ -74,28 +80,81 @@ fun PopUp(
     content: @Composable () -> Unit = {},
 ) {
     val interactionSource by remember { mutableStateOf(MutableInteractionSource()) }
-    Box(
-        modifier = Modifier
-            .imePadding()
-            .fillMaxHeight()
-            .fillMaxWidth()
-            .clickable(interactionSource, null, onClick = onClose)
-            .background(Black.copy(.25f))
-            .padding(25.dp),
-        contentAlignment = Alignment.Center
+    Dialog(
+        onDismissRequest = onClose,
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false,
+            decorFitsSystemWindows = true
+        )
     ) {
-        Column(
+        Box(
             modifier = Modifier
+                .imePadding()
+                .fillMaxHeight()
                 .fillMaxWidth()
-                .clip(RoundedCornerShape(20.dp))
-                .clickable(interactionSource = remember { MutableInteractionSource() }, indication = null, true) {
-                    // Disable the ripple when clicking
-                }
-                .background(White)
+                .clickable(interactionSource, null, onClick = onClose)
+                .background(Black.copy(.25f))
                 .padding(25.dp),
-            verticalArrangement = Arrangement.spacedBy(15.dp)
+            contentAlignment = Alignment.Center
         ) {
-            content.invoke()
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(20.dp))
+                    .clickable(interactionSource = remember { MutableInteractionSource() }, indication = null, true) {
+                        // Disable the ripple when clicking
+                    }
+                    .background(White)
+                    .padding(25.dp),
+                verticalArrangement = Arrangement.spacedBy(15.dp)
+            ) {
+                content.invoke()
+            }
         }
+    }
+}
+
+/**
+ * Two columns long array that can display details of a sensor.
+ * @param color the color of the text to display
+ * @param labelLeft the label of the first column
+ * @param valueLeft the value of the first column
+ * @param labelRight the label of the second column
+ * @param valueRight the label of the second column
+ */
+@Composable
+fun SensorDetails(color: Color, labelLeft: String, valueLeft: String, labelRight: String, valueRight: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(25.dp, Alignment.CenterHorizontally)
+    ) {
+        SensorDetail(color, labelLeft, valueLeft)
+        SensorDetail(color, labelRight, valueRight)
+    }
+}
+
+/**
+ * Displays the details of one attribute of a sensor (name of state).
+ * @param color the color of the text
+ * @param title the name of the attribute to display
+ * @param value the value
+ */
+@Composable
+private fun RowScope.SensorDetail(color: Color, title: String, value: String) {
+    Column (
+        Modifier.weight(.5f),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            title,
+            Modifier.alpha(0.5f),
+            color,
+            style = MaterialTheme.typography.bodySmall
+        )
+        Text(
+            value,
+            color = color,
+            style = MaterialTheme.typography.headlineMedium
+        )
     }
 }

--- a/Android/app/src/main/java/fr/uge/structsure/components/Fields.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/components/Fields.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextFieldDefaults.DecorationBox
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -26,7 +25,6 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import fr.uge.structsure.R
 import fr.uge.structsure.ui.theme.LightGray
 import fr.uge.structsure.ui.theme.White
@@ -100,7 +98,6 @@ fun InputTextArea (
 /**
  * Field containing a single line text input and a label.
  * @param modifier to customise the text input
- * @param label the name of the field
  * @param value the variable in which the value will be stored
  * @param placeholder indicative text placed in the input when no
  *     value is typed

--- a/Android/app/src/main/java/fr/uge/structsure/scanPage/presentation/ScanPage.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/scanPage/presentation/ScanPage.kt
@@ -36,6 +36,7 @@ import fr.uge.structsure.scanPage.domain.ScanState
 import fr.uge.structsure.scanPage.domain.ScanViewModel
 import fr.uge.structsure.scanPage.presentation.components.ScanWeather
 import fr.uge.structsure.scanPage.presentation.components.SensorsList
+import fr.uge.structsure.structuresPage.data.SensorDB
 import fr.uge.structsure.ui.theme.Black
 import fr.uge.structsure.ui.theme.LightGray
 
@@ -58,7 +59,7 @@ fun ScanPage(context: Context,
 
     val currentState = scanViewModel.currentScanState.observeAsState(initial = ScanState.NOT_STARTED)
     scanViewModel.setStructure(structureId)
-    var showPopup by remember { mutableStateOf(true) }
+    var sensorPopup by remember { mutableStateOf<SensorDB?>(null) } // Control the popup visibility and hold popup data
 
     Page(
         Modifier.padding(bottom = 100.dp),
@@ -83,10 +84,10 @@ fun ScanPage(context: Context,
             )
         }
     ) { scrollState ->
-        if (showPopup) SensorPopUp { showPopup = false }
+        if (sensorPopup != null) SensorPopUp({ sensorPopup = null }, { sensorPopup = null })
         ScanWeather(viewModel = scanViewModel, scrollState)
         PlansView()
-        SensorsList(viewModel = scanViewModel)
+        SensorsList(scanViewModel) { s -> sensorPopup = s }
 
         scanViewModel.sensorMessages.observeAsState(null).value?.let {
             Toast.makeText(context, it, Toast.LENGTH_SHORT).show()
@@ -101,10 +102,10 @@ fun ScanPage(context: Context,
 }
 
 @Composable
-private fun SensorPopUp(onSubmit: () -> Unit) {
+private fun SensorPopUp(onSubmit: () -> Unit, onCancel: () -> Unit) {
     var note by remember { mutableStateOf("") }
 
-    PopUp(onSubmit) {
+    PopUp(onCancel) {
         Title("Capteur 04", false) {
             Button(R.drawable.check, "valider", MaterialTheme.colorScheme.onSurface, MaterialTheme.colorScheme.surface, onSubmit)
         }
@@ -134,6 +135,6 @@ private fun SensorPopUp(onSubmit: () -> Unit) {
             label = "Note",
             value = note,
             placeholder = "Aucune note pour le moment"
-        ) { s -> note = s }
+        ) { s -> if (s.length <= 1000) note = s }
     }
 }

--- a/Android/app/src/main/java/fr/uge/structsure/scanPage/presentation/ScanPage.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/scanPage/presentation/ScanPage.kt
@@ -2,18 +2,42 @@ package fr.uge.structsure.scanPage.presentation
 
 import android.content.Context
 import android.widget.Toast
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
+import fr.uge.structsure.R
 import fr.uge.structsure.bluetooth.cs108.Cs108Connector
+import fr.uge.structsure.components.Button
+import fr.uge.structsure.components.InputTextArea
 import fr.uge.structsure.components.Page
+import fr.uge.structsure.components.PopUp
+import fr.uge.structsure.components.SensorDetails
+import fr.uge.structsure.components.Title
 import fr.uge.structsure.scanPage.domain.ScanState
 import fr.uge.structsure.scanPage.domain.ScanViewModel
-import fr.uge.structsure.scanPage.presentation.components.SensorsList
 import fr.uge.structsure.scanPage.presentation.components.ScanWeather
+import fr.uge.structsure.scanPage.presentation.components.SensorsList
+import fr.uge.structsure.ui.theme.Black
+import fr.uge.structsure.ui.theme.LightGray
 
 /**
  * Home screen of the application when the user starts a scan.
@@ -34,6 +58,7 @@ fun ScanPage(context: Context,
 
     val currentState = scanViewModel.currentScanState.observeAsState(initial = ScanState.NOT_STARTED)
     scanViewModel.setStructure(structureId)
+    var showPopup by remember { mutableStateOf(true) }
 
     Page(
         Modifier.padding(bottom = 100.dp),
@@ -58,6 +83,7 @@ fun ScanPage(context: Context,
             )
         }
     ) { scrollState ->
+        if (showPopup) SensorPopUp { showPopup = false }
         ScanWeather(viewModel = scanViewModel, scrollState)
         PlansView()
         SensorsList(viewModel = scanViewModel)
@@ -72,4 +98,42 @@ fun ScanPage(context: Context,
             navController.navigate("Alerte?state=${it.state}&name=${it.sensorName}&lastState=${it.lastStateSensor}")
         }
    }
+}
+
+@Composable
+private fun SensorPopUp(onSubmit: () -> Unit) {
+    var note by remember { mutableStateOf("") }
+
+    PopUp(onSubmit) {
+        Title("Capteur 04", false) {
+            Button(R.drawable.check, "valider", MaterialTheme.colorScheme.onSurface, MaterialTheme.colorScheme.surface, onSubmit)
+        }
+
+        Column(
+            verticalArrangement = Arrangement.spacedBy(5.dp, Alignment.CenterVertically),
+            horizontalAlignment = Alignment.Start,
+        ) {
+            Text(
+                text = "OA Zone 04",
+                style = MaterialTheme.typography.headlineMedium
+            )
+            Image(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(156.dp)
+                    .clip(shape = RoundedCornerShape(size = 15.dp))
+                    .border(width = 3.dp, color = LightGray, shape = RoundedCornerShape(size = 15.dp)),
+                painter = painterResource(id = R.drawable.plan_glaciere),
+                contentDescription = "Plan",
+
+            )
+        }
+        SensorDetails(Black, "Etat courant:", "Non scanné", "Dernier état:", "OK")
+
+        InputTextArea(
+            label = "Note",
+            value = note,
+            placeholder = "Aucune note pour le moment"
+        ) { s -> note = s }
+    }
 }

--- a/Android/app/src/main/java/fr/uge/structsure/scanPage/presentation/components/SensorsList.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/scanPage/presentation/components/SensorsList.kt
@@ -2,10 +2,8 @@ package fr.uge.structsure.scanPage.presentation.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
@@ -23,6 +21,7 @@ import androidx.compose.ui.unit.dp
 import fr.uge.structsure.R
 import fr.uge.structsure.components.Button
 import fr.uge.structsure.scanPage.domain.ScanViewModel
+import fr.uge.structsure.structuresPage.data.SensorDB
 import fr.uge.structsure.ui.theme.Typography
 import fr.uge.structsure.ui.theme.White
 
@@ -30,9 +29,10 @@ import fr.uge.structsure.ui.theme.White
  * A composable function that displays a list of sensors during a scan.
  *
  * @param viewModel The ViewModel that provides the sensor data.
+ * @param onClick action to run once a sensor of the list is clicked
  */
 @Composable
-fun SensorsList(viewModel: ScanViewModel) {
+fun SensorsList(viewModel: ScanViewModel, onClick: (sensor: SensorDB) -> Unit) {
     val sensors by viewModel.sensorsNotScanned.observeAsState(emptyList())
 
     Column(
@@ -66,8 +66,7 @@ fun SensorsList(viewModel: ScanViewModel) {
         ) {
             items(sensors) { sensor ->
                 val state = SensorState.from(sensor.state)
-                SensorBean(Modifier.fillMaxWidth(), sensor.name, state) {
-                }
+                SensorBean(Modifier.fillMaxWidth(), sensor.name, state) { onClick(sensor) }
             }
         }
     }


### PR DESCRIPTION
Ajout d'une modale statique pour consulter les détails d'un capteur. La popup l'affiche quand on clique sur un capteur dans la liste (page de scan). On peut la fermer en annulant les modifications si on clique en dehors de la popup (non fonctionnel puisque statique, mais prévu pour l'être dans le futur), ou en sauvegardant si on clique sur le bouton de confirmation.