### PR TITLE
#100 reglage de la sensibilite de linterrogateur

### DIFF
--- a/Android/app/src/main/java/fr/uge/structsure/MainActivity.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/MainActivity.kt
@@ -32,13 +32,13 @@ import fr.uge.structsure.bluetooth.cs108.Cs108Connector
 import fr.uge.structsure.bluetooth.cs108.Cs108Connector.Companion.bluetoothAdapter
 import fr.uge.structsure.connexionPage.ConnexionCard
 import fr.uge.structsure.database.AppDatabase
+import fr.uge.structsure.structuresPage.domain.StructureViewModel
+import fr.uge.structsure.structuresPage.domain.StructureViewModelFactory
+import fr.uge.structsure.structuresPage.presentation.HomePage
 import fr.uge.structsure.retrofit.RetrofitInstance
 import fr.uge.structsure.scanPage.domain.ScanViewModel
 import fr.uge.structsure.scanPage.presentation.ScanPage
 import fr.uge.structsure.settingsPage.presentation.SettingsPage
-import fr.uge.structsure.structuresPage.domain.StructureViewModel
-import fr.uge.structsure.structuresPage.domain.StructureViewModelFactory
-import fr.uge.structsure.structuresPage.presentation.HomePage
 import java.util.concurrent.atomic.AtomicBoolean
 
 

--- a/Android/app/src/main/java/fr/uge/structsure/components/Containers.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/components/Containers.kt
@@ -9,16 +9,24 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults.Indicator
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -30,7 +38,9 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import fr.uge.structsure.R
 import fr.uge.structsure.ui.theme.Black
+import fr.uge.structsure.ui.theme.LightGray
 import fr.uge.structsure.ui.theme.White
+import kotlinx.coroutines.launch
 
 @Composable
 @Preview
@@ -156,5 +166,51 @@ private fun RowScope.SensorDetail(color: Color, title: String, value: String) {
             color = color,
             style = MaterialTheme.typography.headlineMedium
         )
+    }
+}
+
+/**
+ * List that can trigger refresh event to reload structures list.
+ * @param isRefreshing whether or not the data  is currently being reloaded
+ * @param onRefresh action to run on refresh request
+ * @param content the element to put in the column
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PullToRefresh(modifier: Modifier = Modifier, isRefreshing: Boolean, onRefresh: () -> Unit, content: @Composable () -> Unit) {
+    val coroutineScope = rememberCoroutineScope()
+    val state = rememberPullToRefreshState()
+
+    PullToRefreshBox(
+        modifier = Modifier.fillMaxWidth()
+            .fillMaxSize()
+            .clip(RoundedCornerShape(20.dp)),
+        contentAlignment = Alignment.TopCenter,
+        isRefreshing = isRefreshing,
+        onRefresh = {
+            coroutineScope.launch {
+                onRefresh()
+            }
+        },
+        state = state,
+        indicator = {
+            Indicator(
+                modifier = Modifier.align(Alignment.TopCenter),
+                isRefreshing = isRefreshing,
+                containerColor = LightGray,
+                color = Black,
+                state = state
+            )
+        }
+    ) {
+        val scrollState = rememberScrollState()
+        Column(
+            modifier = Modifier.fillMaxSize()
+                .verticalScroll(scrollState)
+                .then(modifier),
+            verticalArrangement = Arrangement.spacedBy(15.dp)
+        ) {
+            content()
+        }
     }
 }

--- a/Android/app/src/main/java/fr/uge/structsure/components/Fields.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/components/Fields.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import fr.uge.structsure.R
 import fr.uge.structsure.ui.theme.LightGray
+import fr.uge.structsure.ui.theme.Red
 import fr.uge.structsure.ui.theme.White
 
 /**
@@ -45,10 +46,11 @@ fun InputText(
     label: String,
     value: String,
     placeholder: String = "",
+    errorMessage: String? = null,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
     onChange: (String) -> Unit = {}
 ) {
-    Input(modifier, label, value, placeholder, false, onChange, false, keyboardOptions)
+    Input(modifier, label, value, placeholder, errorMessage, false, onChange, false, keyboardOptions)
 }
 
 /**
@@ -70,7 +72,7 @@ fun InputPassword(
     placeholder: String = "",
     onChange: (String) -> Unit = {}
 )  {
-    Input(modifier, label, value, placeholder, true, onChange)
+    Input(modifier, label, value, placeholder, null, true, onChange)
 }
 
 /**
@@ -92,7 +94,7 @@ fun InputTextArea (
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
     onChange: (String) -> Unit = {}
 ) {
-    Input(Modifier.defaultMinSize(minHeight = 75.dp).then(modifier), label, value, placeholder, false, onChange, true, keyboardOptions)
+    Input(Modifier.defaultMinSize(minHeight = 75.dp).then(modifier), label, value, placeholder, null, false, onChange, true, keyboardOptions)
 }
 
 /**
@@ -147,6 +149,7 @@ private fun Input(
     label: String,
     value: String,
     placeholder: String,
+    errorMessage: String?,
     password: Boolean,
     onChange: (String) -> Unit,
     multiLines: Boolean = false,
@@ -177,6 +180,14 @@ private fun Input(
                 innerTextField.invoke()
             }
         )
+        errorMessage?.let {
+            Text(
+                text = errorMessage,
+                style = MaterialTheme.typography.bodyMedium,
+                color = Red,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
     }
 }
 

--- a/Android/app/src/main/java/fr/uge/structsure/database/AppDatabase.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/database/AppDatabase.kt
@@ -8,16 +8,18 @@ import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import fr.uge.structsure.connexionPage.data.AccountDao
 import fr.uge.structsure.connexionPage.data.AccountEntity
-import fr.uge.structsure.scanPage.data.ResultSensors
-import fr.uge.structsure.scanPage.data.ScanEntity
-import fr.uge.structsure.scanPage.data.dao.ResultDao
-import fr.uge.structsure.scanPage.data.dao.ScanDao
 import fr.uge.structsure.structuresPage.data.PlanDB
 import fr.uge.structsure.structuresPage.data.PlanDao
 import fr.uge.structsure.structuresPage.data.SensorDB
 import fr.uge.structsure.structuresPage.data.SensorDao
 import fr.uge.structsure.structuresPage.data.StructureDao
 import fr.uge.structsure.structuresPage.data.StructureData
+import fr.uge.structsure.scanPage.data.ResultSensors
+import fr.uge.structsure.scanPage.data.ScanEntity
+import fr.uge.structsure.scanPage.data.StructureEntity
+import fr.uge.structsure.scanPage.data.dao.ResultDao
+import fr.uge.structsure.scanPage.data.dao.ScanDao
+import fr.uge.structsure.scanPage.data.dao.StructurePlanDao
 
 /**
  * BDD Room for StructSure app.

--- a/Android/app/src/main/java/fr/uge/structsure/database/AppDatabase.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/database/AppDatabase.kt
@@ -8,18 +8,16 @@ import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import fr.uge.structsure.connexionPage.data.AccountDao
 import fr.uge.structsure.connexionPage.data.AccountEntity
+import fr.uge.structsure.scanPage.data.ResultSensors
+import fr.uge.structsure.scanPage.data.ScanEntity
+import fr.uge.structsure.scanPage.data.dao.ResultDao
+import fr.uge.structsure.scanPage.data.dao.ScanDao
 import fr.uge.structsure.structuresPage.data.PlanDB
 import fr.uge.structsure.structuresPage.data.PlanDao
 import fr.uge.structsure.structuresPage.data.SensorDB
 import fr.uge.structsure.structuresPage.data.SensorDao
 import fr.uge.structsure.structuresPage.data.StructureDao
 import fr.uge.structsure.structuresPage.data.StructureData
-import fr.uge.structsure.scanPage.data.ResultSensors
-import fr.uge.structsure.scanPage.data.ScanEntity
-import fr.uge.structsure.scanPage.data.StructureEntity
-import fr.uge.structsure.scanPage.data.dao.ResultDao
-import fr.uge.structsure.scanPage.data.dao.ScanDao
-import fr.uge.structsure.scanPage.data.dao.StructurePlanDao
 
 /**
  * BDD Room for StructSure app.
@@ -32,7 +30,7 @@ import fr.uge.structsure.scanPage.data.dao.StructurePlanDao
 @Database(
     entities = [ScanEntity::class, AccountEntity::class,
         StructureData::class, SensorDB::class, PlanDB::class, ResultSensors::class],
-    version = 12,
+    version = 13,
     exportSchema = false
 )
 /**

--- a/Android/app/src/main/java/fr/uge/structsure/scanPage/domain/ScanViewModel.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/scanPage/domain/ScanViewModel.kt
@@ -8,12 +8,14 @@ import androidx.lifecycle.viewModelScope
 import fr.uge.structsure.MainActivity.Companion.db
 import fr.uge.structsure.bluetooth.cs108.Cs108Connector
 import fr.uge.structsure.bluetooth.cs108.Cs108Scanner
-import fr.uge.structsure.structuresPage.data.SensorDB
+import fr.uge.structsure.bluetooth.cs108.RfidChip
 import fr.uge.structsure.scanPage.data.ResultSensors
 import fr.uge.structsure.scanPage.data.ScanEntity
 import fr.uge.structsure.scanPage.data.cache.SensorCache
 import fr.uge.structsure.scanPage.data.repository.ScanRepository
 import fr.uge.structsure.scanPage.presentation.components.SensorState
+import fr.uge.structsure.settingsPage.presentation.PreferencesManager.getScannerSensitivity
+import fr.uge.structsure.structuresPage.data.SensorDB
 import fr.uge.structsure.structuresPage.domain.StructureViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -24,6 +26,10 @@ import java.sql.Timestamp
  * It interacts with the database, sensor cache, and scanner hardware to handle sensor states and user actions.
  */
 class ScanViewModel(context: Context, private val structureViewModel: StructureViewModel) : ViewModel() {
+
+    companion object {
+        const val TAG = "ScanViewModel"
+    }
 
     /** DAO to interact with the scan database */
     private val scanDao = db.scanDao()
@@ -46,7 +52,7 @@ class ScanViewModel(context: Context, private val structureViewModel: StructureV
     /** Scanner hardware for reading RFID chips */
     private val cs108Scanner =
         Cs108Scanner { chip ->
-            onTagScanned(chip.id)
+            onTagScanned(context, chip)
         }
 
     /** Current state of the scan process: NOT_STARTED, STARTED, PAUSED, STOPPED */
@@ -141,12 +147,13 @@ class ScanViewModel(context: Context, private val structureViewModel: StructureV
 
     /**
      * Adds a scanned RFID chip ID to the buffer for processing.
-     *
-     * @param chipId ID of the scanned RFID chip.
+     * @param chip The details of the scanned chip
      */
-    private fun onTagScanned(chipId: String) {
-        if(chipId == "") return
-        rfidBuffer.add(chipId)
+    private fun onTagScanned(context: Context, chip: RfidChip) {
+        val sensitivity = getScannerSensitivity(context)
+        if (chip.id == "") return
+        if (chip.attenuation > sensitivity[0] || chip.attenuation < sensitivity[1]) return
+        rfidBuffer.add(chip.id)
     }
 
     /**

--- a/Android/app/src/main/java/fr/uge/structsure/scanPage/domain/ScanViewModel.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/scanPage/domain/ScanViewModel.kt
@@ -8,12 +8,12 @@ import androidx.lifecycle.viewModelScope
 import fr.uge.structsure.MainActivity.Companion.db
 import fr.uge.structsure.bluetooth.cs108.Cs108Connector
 import fr.uge.structsure.bluetooth.cs108.Cs108Scanner
+import fr.uge.structsure.structuresPage.data.SensorDB
 import fr.uge.structsure.scanPage.data.ResultSensors
 import fr.uge.structsure.scanPage.data.ScanEntity
 import fr.uge.structsure.scanPage.data.cache.SensorCache
 import fr.uge.structsure.scanPage.data.repository.ScanRepository
 import fr.uge.structsure.scanPage.presentation.components.SensorState
-import fr.uge.structsure.structuresPage.data.SensorDB
 import fr.uge.structsure.structuresPage.domain.StructureViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch

--- a/Android/app/src/main/java/fr/uge/structsure/scanPage/presentation/ScanPage.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/scanPage/presentation/ScanPage.kt
@@ -33,11 +33,11 @@ import fr.uge.structsure.components.PopUp
 import fr.uge.structsure.components.SensorDetails
 import fr.uge.structsure.components.Title
 import fr.uge.structsure.navigateNoReturn
+import fr.uge.structsure.structuresPage.data.SensorDB
 import fr.uge.structsure.scanPage.domain.ScanState
 import fr.uge.structsure.scanPage.domain.ScanViewModel
 import fr.uge.structsure.scanPage.presentation.components.ScanWeather
 import fr.uge.structsure.scanPage.presentation.components.SensorsList
-import fr.uge.structsure.structuresPage.data.SensorDB
 import fr.uge.structsure.ui.theme.Black
 import fr.uge.structsure.ui.theme.LightGray
 

--- a/Android/app/src/main/java/fr/uge/structsure/scanPage/presentation/components/ScanWeather.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/scanPage/presentation/components/ScanWeather.kt
@@ -36,8 +36,8 @@ import fr.uge.structsure.ui.theme.LightGray
 import fr.uge.structsure.ui.theme.White
 
 
-private val Int.toDp: Dp get() = (this / getSystem().displayMetrics.density).toInt().dp
-private val Int.toPx: Int get() = (this * getSystem().displayMetrics.density).toInt()
+val Int.toDp: Dp get() = (this / getSystem().displayMetrics.density).toInt().dp
+val Int.toPx: Int get() = (this * getSystem().displayMetrics.density).toInt()
 
 /**
  * Header of the Scan page that contains the name of the structure,

--- a/Android/app/src/main/java/fr/uge/structsure/scanPage/presentation/components/SensorsList.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/scanPage/presentation/components/SensorsList.kt
@@ -20,8 +20,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import fr.uge.structsure.R
 import fr.uge.structsure.components.Button
-import fr.uge.structsure.scanPage.domain.ScanViewModel
 import fr.uge.structsure.structuresPage.data.SensorDB
+import fr.uge.structsure.scanPage.domain.ScanViewModel
 import fr.uge.structsure.ui.theme.Typography
 import fr.uge.structsure.ui.theme.White
 

--- a/Android/app/src/main/java/fr/uge/structsure/settingsPage/presentation/PreferencesManager.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/settingsPage/presentation/PreferencesManager.kt
@@ -15,15 +15,14 @@ import kotlinx.coroutines.launch
  * This class ensures that data is stored persistently and can be accessed across application sessions.
  */
 object PreferencesManager {
-    /**
-     * The name of the SharedPreferences file.
-     */
+    /** The name of the SharedPreferences file */
     private const val PREFERENCES_NAME = "app_preferences"
 
-    /**
-     * The key used to store the server URL in SharedPreferences.
-     */
+    /** The key used to store the server URL in SharedPreferences */
     private const val SERVER_URL_KEY = "server_url"
+
+    /** The key used to store the scanner sensitivity in SharedPreferences */
+    private const val SENSITIVITY_KEY = "sensitivity"
 
     /**
      * Retrieves the SharedPreferences instance.
@@ -53,6 +52,25 @@ object PreferencesManager {
     fun getServerUrl(context: Context): String? =
         getPreferences(context).getString(SERVER_URL_KEY, null)
 
+    /**
+     * Saves the given sensitivity range in SharedPreferences.
+     * @param context The context used to access SharedPreferences.
+     * @param min The nearest attenuation allowed
+     * @param max The farthest attenuation allowed
+     */
+    fun saveScannerSensitivity(context: Context, min: Int, max: Int) {
+        getPreferences(context).edit().putString(SENSITIVITY_KEY, "$min:$max").apply()
+    }
+
+    /**
+     * Retrieves the sensitivity range in SharedPreferences.
+     * @param context The context used to access SharedPreferences.
+     */
+    fun getScannerSensitivity(context: Context): List<Int> =
+        getPreferences(context).getString(SENSITIVITY_KEY, "0:100")
+            ?.split(":")
+            ?.map { -it.toInt() }
+            ?: listOf(0, -100)
 
     /**
      * Clears the server URL from SharedPreferences.
@@ -61,9 +79,8 @@ object PreferencesManager {
      * This method is also used when the user changes the server URL.
      *
      * @param context The context used to access SharedPreferences.
-     *
      */
-    fun clearServerUrl(context: Context) {
+    fun deleteUserData(context: Context) {
         val db = AppDatabase.getDatabase(context)
         val structureRepository = StructureRepository()
         CoroutineScope(Dispatchers.IO).launch {

--- a/Android/app/src/main/java/fr/uge/structsure/structuresPage/data/Sensor.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/structuresPage/data/Sensor.kt
@@ -23,7 +23,7 @@ data class SensorDB(
     val measureChip: String,
     val name: String,
     val note: String?,
-    val installationDate: String,
+    val installationDate: String?,
     val state: String,
     val plan: Long?,
     val x: Double,

--- a/Android/app/src/main/java/fr/uge/structsure/structuresPage/domain/ConnectivityViewModel.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/structuresPage/domain/ConnectivityViewModel.kt
@@ -1,19 +1,17 @@
 package fr.uge.structsure.structuresPage.domain
 
+
 import android.content.Context
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.os.Build
-import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
-import kotlinx.coroutines.launch
-
-
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 class ConnectivityViewModelFactory(private val context: Context) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {

--- a/Android/app/src/main/java/fr/uge/structsure/structuresPage/domain/StructureViewModel.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/structuresPage/domain/StructureViewModel.kt
@@ -45,7 +45,7 @@ class StructureViewModel(private val structureRepository: StructureRepository,
     }
 
     private val connectivityViewModel: ConnectivityViewModel = ConnectivityViewModel(context)
-    val getAllStructures = MutableLiveData<List<StructureData>?>()
+    val getAllStructures = MutableLiveData<List<StructureWithState>?>()
     val isRefreshing: MutableLiveData<Boolean> = MutableLiveData(false)
     private val uploadInProgress = MutableLiveData<Boolean>(false)
     

--- a/Android/app/src/main/java/fr/uge/structsure/structuresPage/domain/StructureViewModel.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/structuresPage/domain/StructureViewModel.kt
@@ -13,6 +13,7 @@ import fr.uge.structsure.structuresPage.data.StructureData
 import fr.uge.structsure.structuresPage.data.StructureRepository
 import fr.uge.structsure.structuresPage.presentation.components.StructureStates
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 /**
@@ -44,7 +45,8 @@ class StructureViewModel(private val structureRepository: StructureRepository,
     }
 
     private val connectivityViewModel: ConnectivityViewModel = ConnectivityViewModel(context)
-    val getAllStructures = MutableLiveData<List<StructureWithState>?>()
+    val getAllStructures = MutableLiveData<List<StructureData>?>()
+    val isRefreshing: MutableLiveData<Boolean> = MutableLiveData(false)
     private val uploadInProgress = MutableLiveData<Boolean>(false)
     
     /**
@@ -65,17 +67,13 @@ class StructureViewModel(private val structureRepository: StructureRepository,
      */
     fun getAllStructures() {
         viewModelScope.launch {
+            val end = System.currentTimeMillis() + 500
+            isRefreshing.postValue(true)
             val structures = structureRepository.getAllStructures().map { StructureWithState(it) }
             getAllStructures.postValue(structures)
-        }
-    }
-
-
-    fun findAll() {
-        viewModelScope.launch {
-            val structures = structureRepository.getAllStructures()
-                .map { StructureWithState(it) }
-            getAllStructures.postValue(structures)
+            val remaining = end - System.currentTimeMillis()
+            if (remaining > 0) delay(remaining)
+            isRefreshing.postValue(false)
         }
     }
 
@@ -98,7 +96,7 @@ class StructureViewModel(private val structureRepository: StructureRepository,
     fun delete(structureId: Long){
         viewModelScope.launch {
             structureRepository.deleteStructure(structureId, context)
-            findAll() // forces refresh to adapt to connectivity state
+            getAllStructures() // forces refresh to adapt to connectivity state
         }
     }
 

--- a/Android/app/src/main/java/fr/uge/structsure/structuresPage/presentation/HomePage.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/structuresPage/presentation/HomePage.kt
@@ -1,16 +1,19 @@
 package fr.uge.structsure.structuresPage.presentation
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import fr.uge.structsure.bluetooth.cs108.Cs108Connector
 import fr.uge.structsure.components.BluetoothButton
 import fr.uge.structsure.components.Page
+import fr.uge.structsure.components.PullToRefresh
 import fr.uge.structsure.connexionPage.data.AccountDao
 import fr.uge.structsure.structuresPage.domain.StructureViewModel
 import fr.uge.structsure.structuresPage.presentation.components.AccountInformationsView
@@ -30,17 +33,25 @@ fun HomePage(
 
 
     Page (
-        Modifier.padding(bottom = 75.dp),
+        Modifier.fillMaxSize(),
         navController = navController,
+        scrollable = false,
         bottomBar = {
             Box (Modifier.systemBarsPadding().padding(horizontal = 20.dp, vertical = 15.dp)) {
                 BluetoothButton(connexionCS108, true)
             }
         }
     ) {
-        AccountInformationsView(dao, navController)
-        StructuresListView(structureViewModel, navController)
-        ConnectivityStatus()
+        val isRefreshing = structureViewModel.isRefreshing.observeAsState()
+        PullToRefresh(
+            Modifier.padding(bottom = 75.dp),
+            isRefreshing.value == true,
+            { structureViewModel.getAllStructures() }
+        ) {
+            AccountInformationsView(dao, navController)
+            StructuresListView(structureViewModel, navController)
+            ConnectivityStatus()
+        }
     }
 
 }

--- a/Android/app/src/main/java/fr/uge/structsure/structuresPage/presentation/components/SearchBar.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/structuresPage/presentation/components/SearchBar.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import fr.uge.structsure.components.InputSearch
 
 @Composable

--- a/Android/app/src/main/java/fr/uge/structsure/structuresPage/presentation/components/StructuresListView.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/structuresPage/presentation/components/StructuresListView.kt
@@ -2,20 +2,37 @@ package fr.uge.structsure.structuresPage.presentation.components
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults.Indicator
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.intl.Locale
+import androidx.compose.ui.text.toLowerCase
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import fr.uge.structsure.MainActivity
 import fr.uge.structsure.structuresPage.data.StructureData
 import fr.uge.structsure.structuresPage.domain.StructureViewModel
+import fr.uge.structsure.ui.theme.Black
+import fr.uge.structsure.ui.theme.LightGray
 import fr.uge.structsure.ui.theme.Typography
+import kotlinx.coroutines.launch
 
 @Composable
 fun StructuresListView(
@@ -25,13 +42,13 @@ fun StructuresListView(
     val structures = structureViewModel.getAllStructures.observeAsState()
 
     LaunchedEffect(structureViewModel) {
-        structureViewModel.findAll()
+        structureViewModel.getAllStructures()
     }
 
     val searchByName = remember { mutableStateOf("") }
 
     Column(
-        modifier = Modifier,
+        modifier = Modifier.fillMaxSize(),
         verticalArrangement = Arrangement.spacedBy(15.dp)
     ) {
         Text(


### PR DESCRIPTION
Sauvegarde des valeurs du sélecteur de la sensibilité de l'interrogateur depuis les paramètres et filtrage des tags lus selon ces valeurs.

J'en ai profité pour ajouter un refresh manuel de la liste des ouvrages en plus des actualisations automatiques qu'on avait déjà. Ca peut toujours être utile plutôt que de relancer l'application.