### PR TITLE
#204 poser un capteur sur un plan

### DIFF
--- a/Android/app/src/main/java/fr/uge/structsure/MainActivity.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/MainActivity.kt
@@ -228,8 +228,13 @@ fun NavController.navigateNoReturn(route: String) {
  * the current page as the next page to display after login success.
  */
 fun NavController.requestLogin() {
-    var backRoute = currentBackStackEntry?.destination?.route
-    if (backRoute == null || backRoute.startsWith("LoginPage")) backRoute = MainActivity.HOME_PAGE
+    var backRoute = currentBackStackEntry?.destination?.route ?: MainActivity.HOME_PAGE
+    if (backRoute.startsWith("LoginPage")) backRoute = MainActivity.HOME_PAGE
+    currentBackStackEntry?.arguments?.let { bundle ->
+        bundle.keySet().forEach { key ->
+            backRoute = backRoute.replaceFirst("{$key}", bundle.getString(key) ?: "Null")
+        }
+    }
     navigate("LoginPage?backRoute=$backRoute") {
         popUpTo(0) { inclusive = true } // Prevent going back
         launchSingleTop = true

--- a/Android/app/src/main/java/fr/uge/structsure/components/Containers.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/components/Containers.kt
@@ -62,7 +62,10 @@ fun Title (
     indent: Boolean = true,
     content: @Composable () -> Unit = {}
 ) {
-    Row(Modifier.padding(start = if (indent) 20.dp else 0.dp)) {
+    Row(
+        Modifier.padding(start = if (indent) 20.dp else 0.dp),
+        horizontalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
         Text(text,
             style = MaterialTheme.typography.titleLarge,
             modifier= Modifier

--- a/Android/app/src/main/java/fr/uge/structsure/components/Plan.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/components/Plan.kt
@@ -5,7 +5,9 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.detectTransformGestures
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -18,6 +20,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
@@ -28,8 +31,12 @@ import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
+import fr.uge.structsure.R
 import fr.uge.structsure.scanPage.presentation.components.SensorState
 import fr.uge.structsure.structuresPage.data.SensorDB
+import fr.uge.structsure.ui.theme.Black
+import fr.uge.structsure.ui.theme.Red
+import fr.uge.structsure.ui.theme.White
 import kotlin.math.sqrt
 
 /**
@@ -102,6 +109,39 @@ fun Plan(
                 point(size, panned.x, panned.y, SensorState.from(it.state))
             }
         }
+    }
+}
+
+/**
+ * Component that prompts the user to select a point to place on the
+ * plan.
+ * @param options the list of available sensors
+ * @param onSubmit the action to run when a sensor is selected
+ * @param onCancel the action to run when the cancel button is pressed
+ */
+@Composable
+fun AddPointPane(
+    options: List<String>,
+    onSubmit: (String) -> Unit,
+    onCancel: () -> Unit
+) {
+    var search by remember { mutableStateOf("") }
+    val valid = options.contains(search)
+    Column(
+        Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(15.dp, Alignment.CenterVertically),
+        horizontalAlignment = Alignment.Start
+    ) {
+        Title("Nouveau point", false) {
+            Button(R.drawable.x, "Cancel") { onCancel() }
+            Box (Modifier.alpha(if (valid) 1f else .25f)) {
+                Button(R.drawable.check, "Save", White, Black) {
+                    if (valid) onSubmit(search)
+                }
+            }
+            // Button(R.drawable.trash, "Save", Red, Red.copy(alpha = 0.1f))
+        }
+        ComboBox("Capteur", options, search, { search = it }, if (valid) Black else Red)
     }
 }
 

--- a/Android/app/src/main/java/fr/uge/structsure/components/Plan.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/components/Plan.kt
@@ -40,14 +40,6 @@ import fr.uge.structsure.ui.theme.White
 import kotlin.math.sqrt
 
 /**
- * Represents a point on the plan image.
- * @param x the x coordinate of the point
- * @param y the y coordinate of the point
- * @param state the state of the sensor at this point
- */
-data class Point(val x: Double, val y: Double, val state: SensorState)
-
-/**
  * Composable that displays a plan image and allows to add points on it.
  * @param image the image to display
  * @param points the list of points to display on the image

--- a/Android/app/src/main/java/fr/uge/structsure/components/Plan.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/components/Plan.kt
@@ -5,22 +5,16 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.detectTransformGestures
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
@@ -29,14 +23,11 @@ import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
-import fr.uge.structsure.R
 import fr.uge.structsure.scanPage.presentation.components.SensorState
 import fr.uge.structsure.structuresPage.data.SensorDB
-import fr.uge.structsure.ui.theme.Black
-import fr.uge.structsure.ui.theme.Red
-import fr.uge.structsure.ui.theme.White
 import kotlin.math.sqrt
 
 /**
@@ -47,15 +38,14 @@ import kotlin.math.sqrt
 @Composable
 fun Plan(
     image: Bitmap,
-    points: List<SensorDB>,
+    points: () -> List<SensorDB>,
+    temporaryPoint: SensorDB?,
     addPoint: (Double, Double) -> Unit,
     deletePoint: (SensorDB) -> Unit
 ) {
     val painter = remember(image) { BitmapPainter(image.asImageBitmap()) }
-    val factor = remember(image) { Factor(painter.intrinsicSize) }
-
-    var scale by remember { mutableFloatStateOf(factor.transform) }
-    var offset by remember { mutableStateOf(Offset(0f, 0f)) }
+    val factor = remember(1) { Factor() }
+    factor.init(painter.intrinsicSize)
 
     Box(
         modifier = Modifier
@@ -70,70 +60,26 @@ fun Plan(
             Modifier
                 .fillMaxSize()
                 .pointerInput(Unit) { /* Zoom and pane the image*/
-                    detectTransformGestures { centroid, pan, zoom, _ ->
-                        val adjustment = centroid * (1 - zoom)
-                        offset = (offset + pan) * zoom + adjustment
-                        scale = (scale * zoom).coerceIn(factor.transform, 3 * factor.transform)
-
-                        val width = ((size.width * scale - size.width)/2 - (size.width * factor.offset.x * scale)).coerceAtLeast(0f)
-                        val height = ((size.height * scale - size.height)/2f - (size.height * factor.offset.y * scale)).coerceAtLeast(0f)
-                        offset = Offset(
-                            offset.x.coerceIn(-width, width),
-                            offset.y.coerceIn(-height, height)
-                        )
-                    }
+                    detectTransformGestures { centroid, pan, zoom, _ -> factor.updatePanZoom(size, centroid, pan, zoom) }
                 }
                 .pointerInput(Unit) {
                     detectTapGestures(
-                        onTap = { pos -> onTap(factor, size.toSize(), scale, offset, pos, points, addPoint, deletePoint) },
-                        onLongPress = { pos -> onTap(factor, size.toSize(), scale, offset, pos, points, addPoint, deletePoint, true) }
+                        onTap = { pos -> onTap(factor, size.toSize(), pos, points(), addPoint, deletePoint) },
+                        onLongPress = { pos -> onTap(factor, size.toSize(), pos, points(), addPoint, deletePoint, true) }
                     )
                 }
                 .graphicsLayer(
-                    scaleX = scale, scaleY = scale,
-                    translationX = offset.x, translationY = offset.y
+                    scaleX = factor.zoom, scaleY = factor.zoom,
+                    translationX = factor.pan.value.x, translationY = factor.pan.value.y
                 )
         )
         Canvas(Modifier.fillMaxSize()) {
-            val transformPoint = factor.transformPoint(size)
-            points.forEach {
-                val panned = imgToCanvas(offset, scale, size, transformPoint, factor.offset, it.x, it.y)
+            val positions = if (temporaryPoint == null) points() else points() + temporaryPoint
+            positions.forEach {
+                val panned = imgToCanvas(factor, size, it.x, it.y)
                 point(size, panned.x, panned.y, SensorState.from(it.state))
             }
         }
-    }
-}
-
-/**
- * Component that prompts the user to select a point to place on the
- * plan.
- * @param options the list of available sensors
- * @param onSubmit the action to run when a sensor is selected
- * @param onCancel the action to run when the cancel button is pressed
- */
-@Composable
-fun AddPointPane(
-    options: List<String>,
-    onSubmit: (String) -> Unit,
-    onCancel: () -> Unit
-) {
-    var search by remember { mutableStateOf("") }
-    val valid = options.contains(search)
-    Column(
-        Modifier.fillMaxSize(),
-        verticalArrangement = Arrangement.spacedBy(15.dp, Alignment.CenterVertically),
-        horizontalAlignment = Alignment.Start
-    ) {
-        Title("Nouveau point", false) {
-            Button(R.drawable.x, "Cancel") { onCancel() }
-            Box (Modifier.alpha(if (valid) 1f else .25f)) {
-                Button(R.drawable.check, "Save", White, Black) {
-                    if (valid) onSubmit(search)
-                }
-            }
-            // Button(R.drawable.trash, "Save", Red, Red.copy(alpha = 0.1f))
-        }
-        ComboBox("Capteur", options, search, { search = it }, if (valid) Black else Red)
     }
 }
 
@@ -143,8 +89,6 @@ fun AddPointPane(
  * @param factor transformation toolkit to calculate the position in
  *     the image
  * @param size the size of the canvas
- * @param scale the level of zoom currently applied to the image
- * @param offset the level of pan currently applied to the image
  * @param pos the position of the click in the canvas
  * @param points all the points contained in the plan
  * @param long true if the press was a long press, false otherwise
@@ -152,16 +96,14 @@ fun AddPointPane(
 private fun onTap(
     factor: Factor,
     size: Size,
-    scale: Float,
-    offset: Offset,
     pos: Offset,
     points: List<SensorDB>,
     addPoint: (Double, Double) -> Unit,
     deletePoint: (SensorDB) -> Unit,
     long: Boolean = false
 ) {
-    val range = (30 / factor.transform / scale).toInt()
-    val imgPos = canvasToImg(offset, scale, size, factor.transformPoint(size), factor.offset, pos.x, pos.y)
+    val range = (40 / factor.transform / factor.zoom).toInt()
+    val imgPos = canvasToImg(factor, size, pos.x, pos.y)
     for (i in points.indices) {
         if (points[i].inRange(imgPos.x.toDouble(), imgPos.y.toDouble(), range)) {
             if (long) deletePoint(points[i]) else onPointTap(points, i)
@@ -205,44 +147,40 @@ private fun DrawScope.point(size: Size, x: Float, y: Float, state: SensorState) 
 /**
  * Transforms the coordinates of the given point to apply pan and zoom
  * to it and calculates it new position on the screen.
- * @param pan values of the horizontal/vertical displacement to apply
- * @param zoom level of zoom to apply between 1 and 3
+ * @param factor factor holding conversion values
  * @param size the size of the canvas to draw on
- * @param transformPoint factor to correct image scale
- * @param offsetFactor offset to center the image if needed
  * @param x the initial x coordinate in the image
  * @param y the initial y coordinate in the image
  */
-private fun imgToCanvas(pan: Offset, zoom: Float, size: Size, transformPoint: Float, offsetFactor: Offset, x: Double, y: Double): Offset {
+private fun imgToCanvas(factor: Factor, size: Size, x: Double, y: Double): Offset {
+    val transformPoint = factor.transformPoint(size)
     val centerX = size.width / 2f
     val centerY = size.height / 2f
-    val posX = x * transformPoint + size.width * offsetFactor.x
-    val posY = y * transformPoint + size.height * offsetFactor.y
+    val posX = x * transformPoint + size.width * factor.offset.x
+    val posY = y * transformPoint + size.height * factor.offset.y
     return Offset(
-        ((posX - centerX) * zoom + centerX + pan.x).toFloat(),
-        ((posY - centerY) * zoom + centerY + pan.y).toFloat()
+        ((posX - centerX) * factor.zoom + centerX + factor.pan.value.x).toFloat(),
+        ((posY - centerY) * factor.zoom + centerY + factor.pan.value.y).toFloat()
     )
 }
 
 /**
  * Transforms the coordinates of the given point to remove pan and zoom
  * from it and calculates it relative position in the image.
- * @param pan values of the horizontal/vertical displacement to apply
- * @param zoom level of zoom to apply between 1 and 3
+ * @param factor factor holding conversion values
  * @param size the size of the canvas to draw on
- * @param transformPoint factor to correct image scale
- * @param offsetFactor offset to center the image if needed
  * @param x the initial x coordinate in the canvas
  * @param y the initial y coordinate in the canvas
  */
-private fun canvasToImg(pan: Offset, zoom: Float, size: Size, transformPoint: Float, offsetFactor: Offset, x: Float, y: Float): Offset {
+private fun canvasToImg(factor: Factor, size: Size, x: Float, y: Float): Offset {
+    val transformPoint = factor.transformPoint(size)
     val centerX = size.width / 2f
     val centerY = size.height / 2f
-    val posX = (x - centerX - pan.x) / zoom + centerX
-    val posY = (y - centerY - pan.y) / zoom + centerY
+    val posX = (x - centerX - factor.pan.value.x) / factor.zoom + centerX
+    val posY = (y - centerY - factor.pan.value.y) / factor.zoom + centerY
     return Offset(
-        ((posX - size.width * offsetFactor.x) / transformPoint).toInt().toFloat(),
-        ((posY - size.height * offsetFactor.y) / transformPoint).toInt().toFloat()
+        ((posX - size.width * factor.offset.x) / transformPoint).toInt().toFloat(),
+        ((posY - size.height * factor.offset.y) / transformPoint).toInt().toFloat()
     )
 }
 
@@ -268,18 +206,39 @@ private fun SensorDB.inRange(x: Double, y: Double, range: Int): Boolean {
  * Object containing all the values that enable to switch from original
  * image coordinates to rescaled to panned/zoomed coordinates.
  */
-private class Factor(val image: Size) {
+class Factor {
+
+    /** The currently hold image */
+    var image = Size(0f, 0f)
 
     /** Ratio of the canvas calculated on the image original ratio */
-    val canvasRatio = (image.width / image.height).coerceIn(1.5f, 1.75f)
+    var canvasRatio = 1f
 
     /** Factor to go from the original image to the re-scaled image */
-    val transform = ((image.width / canvasRatio) / image.height).coerceAtLeast(1f)
+    var transform = 1f
 
     /** Margin top or left to center the image in the canvas */
-    val offset: Offset
+    var offset = Offset(0f, 0f)
 
-    init {
+    /** The level of zoom of the image */
+    var zoom = transform
+
+    /** The horizontal and vertical displacement of the image */
+    var pan = mutableStateOf(Offset(0f, 0f))
+
+    /**
+     * Initializes this factor for the given image, resetting and
+     * calculating all factor to enable zooming, panning and changing
+     * from screen's reference to image's reference
+     * @param image the size of the loaded image
+     */
+    fun init(image: Size) {
+        if (image == this.image) return
+        this.image = image
+        canvasRatio = (image.width / image.height).coerceIn(1.5f, 1.75f)
+        transform = ((image.width / canvasRatio) / image.height).coerceAtLeast(1f)
+        zoom = transform
+
         /* Compute offset */
         var offsetTop = 0f
         var offsetLeft = 0f
@@ -303,5 +262,26 @@ private class Factor(val image: Size) {
         } else {
             size.height/image.height
         }
+    }
+
+    /**
+     * Updates the pan and zoom values of this factor with the given
+     * inputs from the user
+     * @param size the height and width of the image
+     * @param centroid center of the interaction
+     * @param pan x and y displacements of the image
+     * @param zoom change of the scale of the image
+     */
+    fun updatePanZoom(size: IntSize, centroid: Offset, pan: Offset, zoom: Float) {
+        val adjustment = centroid * (1 - zoom)
+        val offset = (offset + pan) * zoom + adjustment
+        this.zoom = (this.zoom * zoom).coerceIn(transform, 3 * transform)
+
+        val width = ((size.width * this.zoom - size.width)/2 - (size.width * offset.x * this.zoom)).coerceAtLeast(0f)
+        val height = ((size.height * this.zoom - size.height)/2f - (size.height * offset.y * this.zoom)).coerceAtLeast(0f)
+        this.pan.value = Offset(
+            offset.x.coerceIn(-width, width),
+            offset.y.coerceIn(-height, height)
+        )
     }
 }

--- a/Android/app/src/main/java/fr/uge/structsure/components/Plan.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/components/Plan.kt
@@ -41,7 +41,7 @@ fun Plan(
     points: () -> List<SensorDB>,
     temporaryPoint: SensorDB?,
     addPoint: (Double, Double) -> Unit,
-    deletePoint: (SensorDB) -> Unit
+    selectPoint: (SensorDB) -> Unit
 ) {
     val painter = remember(image) { BitmapPainter(image.asImageBitmap()) }
     val factor = remember(1) { Factor() }
@@ -64,8 +64,7 @@ fun Plan(
                 }
                 .pointerInput(Unit) {
                     detectTapGestures(
-                        onTap = { pos -> onTap(factor, size.toSize(), pos, points(), addPoint, deletePoint) },
-                        onLongPress = { pos -> onTap(factor, size.toSize(), pos, points(), addPoint, deletePoint, true) }
+                        onTap = { pos -> onTap(factor, size.toSize(), pos, points(), addPoint, selectPoint) },
                     )
                 }
                 .graphicsLayer(
@@ -91,7 +90,6 @@ fun Plan(
  * @param size the size of the canvas
  * @param pos the position of the click in the canvas
  * @param points all the points contained in the plan
- * @param long true if the press was a long press, false otherwise
  */
 private fun onTap(
     factor: Factor,
@@ -99,27 +97,17 @@ private fun onTap(
     pos: Offset,
     points: List<SensorDB>,
     addPoint: (Double, Double) -> Unit,
-    deletePoint: (SensorDB) -> Unit,
-    long: Boolean = false
+    selectPoint: (SensorDB) -> Unit
 ) {
     val range = (40 / factor.transform / factor.zoom).toInt()
     val imgPos = canvasToImg(factor, size, pos.x, pos.y)
     for (i in points.indices) {
         if (points[i].inRange(imgPos.x.toDouble(), imgPos.y.toDouble(), range)) {
-            if (long) deletePoint(points[i]) else onPointTap(points, i)
+            selectPoint(points[i])
             return
         }
     }
-    if (!long) addPoint(imgPos.x.toDouble(), imgPos.y.toDouble())
-}
-
-/**
- * Action to run when one point is pressed.
- * @param points the list of points that contains the pressed point
- * @param i the index of the point in the list
- */
-private fun onPointTap(points: List<SensorDB>, i: Int) {
-    println("TODO Point pressed: ${points[i]}")
+    addPoint(imgPos.x.toDouble(), imgPos.y.toDouble())
 }
 
 /**

--- a/Android/app/src/main/java/fr/uge/structsure/database/AppDatabase.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/database/AppDatabase.kt
@@ -32,7 +32,7 @@ import fr.uge.structsure.structuresPage.data.StructureData
 @Database(
     entities = [ScanEntity::class, AccountEntity::class,
         StructureData::class, SensorDB::class, PlanDB::class, ResultSensors::class, ScanEdits::class],
-    version = 14,
+    version = 15,
     exportSchema = false
 )
 /**

--- a/Android/app/src/main/java/fr/uge/structsure/database/AppDatabase.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/database/AppDatabase.kt
@@ -32,7 +32,7 @@ import fr.uge.structsure.structuresPage.data.StructureData
 @Database(
     entities = [ScanEntity::class, AccountEntity::class,
         StructureData::class, SensorDB::class, PlanDB::class, ResultSensors::class, ScanEdits::class],
-    version = 15,
+    version = 16,
     exportSchema = false
 )
 /**

--- a/Android/app/src/main/java/fr/uge/structsure/scanPage/data/ScanEdits.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/scanPage/data/ScanEdits.kt
@@ -23,5 +23,5 @@ data class ScanEdits(
  */
 enum class EditType {
     /** Edition of the note of a sensor (creation, edition or deletion) */
-    SENSOR_NOTE
+    SENSOR_NOTE, SENSOR_PLACE
 }

--- a/Android/app/src/main/java/fr/uge/structsure/scanPage/data/ScanEntity.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/scanPage/data/ScanEntity.kt
@@ -7,15 +7,16 @@ import androidx.room.PrimaryKey
  * Entity class for the Scan table.
  * @param id Unique scan ID.
  * @param structureId ID of the associated structure.
- * @param date Scan date (timestamp).
+ * @param startTimestamp time at which the scan began
+ * @param endTimestamp time at which the scan got stopped
  * @param note Note associated with the scan.
  */
 @Entity(tableName = "scan")
 data class ScanEntity(
     @PrimaryKey(autoGenerate = true) val id: Long = 0, // ID unique du scan
     val structureId: Long,
-    val start_timestamp: String,
-    val end_timestamp: String,
+    val startTimestamp: String,
+    val endTimestamp: String,
     val technician: String,
     val note: String
 )

--- a/Android/app/src/main/java/fr/uge/structsure/scanPage/data/dao/ScanDao.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/scanPage/data/dao/ScanDao.kt
@@ -20,7 +20,7 @@ interface ScanDao {
     @Insert
     fun insertScan(scan: ScanEntity): Long
 
-    @Query("UPDATE scan SET end_timestamp = :endTime WHERE id = :scanId")
+    @Query("UPDATE scan SET endTimestamp = :endTime WHERE id = :scanId")
     suspend fun updateEndTimestamp(scanId: Long, endTime: String)
 
     @Query("SELECT * FROM scan WHERE id = :scanId")
@@ -29,10 +29,10 @@ interface ScanDao {
     @Query("SELECT * FROM scan WHERE structureId = :structureId LIMIT 1")
     fun getScanByStructure(structureId: Long): ScanEntity?
 
-    @Query("SELECT * FROM scan WHERE end_timestamp != ''")
+    @Query("SELECT * FROM scan WHERE endTimestamp != ''")
     fun getUnsentScan(): List<ScanEntity>
 
-    @Query("SELECT * FROM scan WHERE end_timestamp == '' LIMIT 1")
+    @Query("SELECT * FROM scan WHERE endTimestamp == '' LIMIT 1")
     fun getUnfinishedScan(): ScanEntity?
 
     @Query("DELETE FROM scan WHERE structureId = :id")

--- a/Android/app/src/main/java/fr/uge/structsure/scanPage/data/network/dto/ScanEditDTO.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/scanPage/data/network/dto/ScanEditDTO.kt
@@ -8,7 +8,10 @@ package fr.uge.structsure.scanPage.data.network.dto
  */
 data class SensorEditDTO(
     val sensorId: String,
-    val note: String?
+    val note: String?,
+    val plan: Long?,
+    val x: Int?,
+    val y: Int?
 ) {
-    constructor(sensorId: String) : this(sensorId, null)
+    constructor(sensorId: String) : this(sensorId, null, null, null, null)
 }

--- a/Android/app/src/main/java/fr/uge/structsure/scanPage/data/repository/ScanRepository.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/scanPage/data/repository/ScanRepository.kt
@@ -100,7 +100,7 @@ class ScanRepository(context: Context) {
         val scanResults = results.map { ScanResultDTO.from(it) }
         val sensorEdits = getSensorEdits(edits)
 
-        return ScanRequestDTO(scan.structureId, scanId, scan.start_timestamp, scan.note, login,
+        return ScanRequestDTO(scan.structureId, scanId, scan.startTimestamp, scan.note, login,
             scanResults, sensorEdits)
     }
 
@@ -119,6 +119,15 @@ class ScanRepository(context: Context) {
                     /* Get the new note of the sensor */
                     val sensor = sensorEdits.getOrPut(it.value) { SensorEditDTO(it.value) }
                     sensorEdits[it.value] = sensor.copy(note = sensorDao.getSensor(it.value)?.note)
+                }
+                EditType.SENSOR_PLACE -> {
+                    /* Get the new position of the sensor */
+                    val sensor = sensorEdits.getOrPut(it.value) { SensorEditDTO(it.value) }
+                    sensorEdits[it.value] = sensor.copy(
+                        plan = sensorDao.getSensor(it.value)?.plan,
+                        x = sensorDao.getSensor(it.value)?.x?.toInt(),
+                        y = sensorDao.getSensor(it.value)?.y?.toInt()
+                    )
                 }
             }
         }

--- a/Android/app/src/main/java/fr/uge/structsure/scanPage/domain/PlanViewModel.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/scanPage/domain/PlanViewModel.kt
@@ -143,4 +143,17 @@ class PlanViewModel(context: Context, private val scanViewModel: ScanViewModel) 
             popupImage.postValue(if (path == null) defaultImage else BitmapFactory.decodeFile(path))
         }
     }
+    
+    /**
+     * Adds a position to a sensor and saves it in the database. The
+     * sensor must have no position defined yet.
+     * @param sensor the sensor to place
+     * @param plan the id of the plan to put the sensor on
+     * @param x the x coordinate of the point in the image
+     * @param y the y coordinate of the point in the image
+     */
+    fun placeSensor(sensor: SensorDB, plan: Long?, x: Double, y: Double) {
+        db.sensorDao().placeSensor(sensor.sensorId, plan, x, y)
+        scanViewModel.refreshSensorStates()
+    }
 }

--- a/Android/app/src/main/java/fr/uge/structsure/scanPage/domain/PlanViewModel.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/scanPage/domain/PlanViewModel.kt
@@ -9,6 +9,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import fr.uge.structsure.MainActivity.Companion.db
 import fr.uge.structsure.R
+import fr.uge.structsure.scanPage.data.EditType
+import fr.uge.structsure.scanPage.data.ScanEdits
 import fr.uge.structsure.scanPage.data.TreeNode
 import fr.uge.structsure.scanPage.data.TreePlan
 import fr.uge.structsure.scanPage.data.TreeSection
@@ -154,6 +156,11 @@ class PlanViewModel(context: Context, private val scanViewModel: ScanViewModel) 
      */
     fun placeSensor(sensor: SensorDB, plan: Long?, x: Double, y: Double) {
         db.sensorDao().placeSensor(sensor.sensorId, plan, x, y)
+        scanViewModel.activeScanId?.let { scanId ->
+            viewModelScope.launch(Dispatchers.IO) {
+                db.scanEditsDao().upsert(ScanEdits(scanId, EditType.SENSOR_PLACE, sensor.sensorId))
+            }
+        }
         scanViewModel.refreshSensorStates()
     }
 }

--- a/Android/app/src/main/java/fr/uge/structsure/scanPage/domain/ScanViewModel.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/scanPage/domain/ScanViewModel.kt
@@ -43,7 +43,8 @@ class ScanViewModel(context: Context, private val structureViewModel: StructureV
     private val accountDao = db.accountDao()
 
     /** ID of the structure being scanned */
-    private var structureId: Long? = null
+    var structureId: Long? = null
+        private set
 
     /** Repository to interact with the scan database */
     private val scanRepository: ScanRepository = ScanRepository(context)
@@ -175,7 +176,7 @@ class ScanViewModel(context: Context, private val structureViewModel: StructureV
     /**
      * Refreshes the states of the sensors after starting a scan.
      */
-    private fun refreshSensorStates() {
+    fun refreshSensorStates() {
         viewModelScope.launch(Dispatchers.IO) {
             val sensors = sensorDao.getAllSensors(structureId?: return@launch)
             val scannedResults = activeScanId?.let { scanId ->

--- a/Android/app/src/main/java/fr/uge/structsure/scanPage/domain/ScanViewModel.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/scanPage/domain/ScanViewModel.kt
@@ -60,6 +60,7 @@ class ScanViewModel(context: Context, private val structureViewModel: StructureV
 
     /** ID of the currently active scan */
     var activeScanId: Long? = null
+        private set
 
     /** Sensor cache for managing sensor states in memory */
     private val sensorCache = SensorCache()
@@ -89,6 +90,9 @@ class ScanViewModel(context: Context, private val structureViewModel: StructureV
 
     /** Displaying error messages when updating notes */
     val noteErrorMessage = MutableLiveData<String>()
+
+    /** Whether a scan has been started or not yet */
+    fun isScanStarted(): Boolean = currentScanState.value != ScanState.NOT_STARTED
 
     /**
      * Update the state of the sensors dynamically in the header of the scan page.
@@ -318,8 +322,8 @@ class ScanViewModel(context: Context, private val structureViewModel: StructureV
 
         val newScan = ScanEntity(
             structureId = structureId,
-            start_timestamp = now,
-            end_timestamp = "",
+            startTimestamp = now,
+            endTimestamp = "",
             technician = accountDao.getLogin(),
             note = ""
         )

--- a/Android/app/src/main/java/fr/uge/structsure/scanPage/presentation/PlansView.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/scanPage/presentation/PlansView.kt
@@ -69,7 +69,7 @@ fun PlansView(scanViewModel: ScanViewModel) {
     var addPoint by remember { mutableStateOf<SensorDB?>(null) }
 
     LaunchedEffect(addPoint) {
-        unplacedSensors = MainActivity.db.sensorDao().getSensorsUnplacedByStructure(scanViewModel.structureId ?: -1)
+        unplacedSensors = MainActivity.db.sensorDao().getSensorsUnplacedByStructure(scanViewModel.structure?.id ?: -1)
     }
 
     Column(
@@ -96,7 +96,7 @@ fun PlansView(scanViewModel: ScanViewModel) {
                 points = { points.value },
                 temporaryPoint = addPoint,
                 addPoint = { x, y -> if (scanViewModel.isScanStarted()) addPoint = SensorDB.point(scanViewModel, x, y) },
-                deletePoint = { /* TODO enable to remove points */ }
+                selectPoint = { /* TODO enable to remove points */ }
             )
 
             Spacer(

--- a/Android/app/src/main/java/fr/uge/structsure/scanPage/presentation/PlansView.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/scanPage/presentation/PlansView.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -34,6 +35,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.distinctUntilChanged
 import fr.uge.structsure.R
+import fr.uge.structsure.components.AddPointPane
 import fr.uge.structsure.components.Plan
 import fr.uge.structsure.scanPage.data.TreePlan
 import fr.uge.structsure.scanPage.data.TreeSection
@@ -87,8 +89,17 @@ fun PlansView(scanViewModel: ScanViewModel) {
                     .height(1.dp)
                     .background(LightGray) )
 
-            plans.value?.let {
-                Section(planViewModel, it, true)
+            var addPoint by remember { mutableStateOf(true) }
+            if (addPoint) {
+                AddPointPane(
+                    listOf("Capteur PA", "Capteur P8S", "Capteur P8N", "Capteur A", "Sensor B"),
+                    { addPoint = false },
+                    { addPoint = false }
+                )
+            } else {
+                plans.value?.let {
+                    Section(planViewModel, it, true)
+                }
             }
         }
     }

--- a/Android/app/src/main/java/fr/uge/structsure/scanPage/presentation/PlansView.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/scanPage/presentation/PlansView.kt
@@ -41,6 +41,8 @@ import fr.uge.structsure.scanPage.data.TreePlan
 import fr.uge.structsure.scanPage.data.TreeSection
 import fr.uge.structsure.scanPage.domain.PlanViewModel
 import fr.uge.structsure.scanPage.domain.ScanViewModel
+import fr.uge.structsure.scanPage.presentation.components.SensorState
+import fr.uge.structsure.structuresPage.data.SensorDB
 import fr.uge.structsure.ui.theme.Black
 import fr.uge.structsure.ui.theme.LightGray
 import fr.uge.structsure.ui.theme.Typography
@@ -56,6 +58,7 @@ fun PlansView(scanViewModel: ScanViewModel) {
     val planViewModel = scanViewModel.planViewModel
     val plans = planViewModel.plans.observeAsState()
     val points = planViewModel.filteredPoints.distinctUntilChanged().observeAsState(listOf())
+    var addPoint by remember { mutableStateOf<SensorDB?>(null) }
 
     Column(
         verticalArrangement = Arrangement.spacedBy(5.dp, Alignment.Top),
@@ -78,8 +81,8 @@ fun PlansView(scanViewModel: ScanViewModel) {
             val image = planViewModel.image.observeAsState(planViewModel.defaultImage)
             Plan(
                 image = image.value,
-                points = points.value,
-                addPoint = { _, _ ->/* TODO enable to place points */ },
+                points = if (addPoint == null) points.value else points.value.plus(addPoint!!),
+                addPoint = { x, y -> addPoint = SensorDB.point(x, y) },
                 deletePoint = { /* TODO enable to remove points */ }
             )
 
@@ -89,12 +92,11 @@ fun PlansView(scanViewModel: ScanViewModel) {
                     .height(1.dp)
                     .background(LightGray) )
 
-            var addPoint by remember { mutableStateOf(true) }
-            if (addPoint) {
+            if (addPoint != null) {
                 AddPointPane(
                     listOf("Capteur PA", "Capteur P8S", "Capteur P8N", "Capteur A", "Sensor B"),
-                    { addPoint = false },
-                    { addPoint = false }
+                    { addPoint = null },
+                    { addPoint = null }
                 )
             } else {
                 plans.value?.let {
@@ -103,6 +105,23 @@ fun PlansView(scanViewModel: ScanViewModel) {
             }
         }
     }
+}
+
+private fun SensorDB.Companion.point(x: Double, y: Double): SensorDB {
+    return SensorDB(
+        sensorId = "",
+        controlChip = "",
+        measureChip = "",
+        name = "",
+        note =
+        "",
+        installationDate = null,
+        state = SensorState.UNKNOWN.name,
+        plan = 0, // TODO
+        x = x,
+        y = y,
+        structureId = 0 // TODO
+    )
 }
 
 /**

--- a/Android/app/src/main/java/fr/uge/structsure/scanPage/presentation/PlansView.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/scanPage/presentation/PlansView.kt
@@ -95,7 +95,7 @@ fun PlansView(scanViewModel: ScanViewModel) {
                 image = image.value,
                 points = { points.value },
                 temporaryPoint = addPoint,
-                addPoint = { x, y -> addPoint = SensorDB.point(scanViewModel, x, y) },
+                addPoint = { x, y -> if (scanViewModel.isScanStarted()) addPoint = SensorDB.point(scanViewModel, x, y) },
                 deletePoint = { /* TODO enable to remove points */ }
             )
 

--- a/Android/app/src/main/java/fr/uge/structsure/scanPage/presentation/PlansView.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/scanPage/presentation/PlansView.kt
@@ -143,7 +143,7 @@ private fun SensorDB.Companion.point(scanViewModel: ScanViewModel, x: Double, y:
         note =
         "",
         installationDate = null,
-        state = SensorState.UNKNOWN.name,
+        _state = SensorState.UNKNOWN.name,
         plan = selectedPlan.plan.id,
         x = x,
         y = y,

--- a/Android/app/src/main/java/fr/uge/structsure/scanPage/presentation/PlansView.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/scanPage/presentation/PlansView.kt
@@ -4,9 +4,11 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -15,6 +17,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
@@ -34,9 +37,12 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.distinctUntilChanged
+import fr.uge.structsure.MainActivity
 import fr.uge.structsure.R
-import fr.uge.structsure.components.AddPointPane
+import fr.uge.structsure.components.Button
+import fr.uge.structsure.components.ComboBox
 import fr.uge.structsure.components.Plan
+import fr.uge.structsure.components.Title
 import fr.uge.structsure.scanPage.data.TreePlan
 import fr.uge.structsure.scanPage.data.TreeSection
 import fr.uge.structsure.scanPage.domain.PlanViewModel
@@ -45,6 +51,7 @@ import fr.uge.structsure.scanPage.presentation.components.SensorState
 import fr.uge.structsure.structuresPage.data.SensorDB
 import fr.uge.structsure.ui.theme.Black
 import fr.uge.structsure.ui.theme.LightGray
+import fr.uge.structsure.ui.theme.Red
 import fr.uge.structsure.ui.theme.Typography
 import fr.uge.structsure.ui.theme.White
 import fr.uge.structsure.ui.theme.fonts
@@ -55,10 +62,15 @@ import fr.uge.structsure.ui.theme.fonts
  */
 @Composable
 fun PlansView(scanViewModel: ScanViewModel) {
+    var unplacedSensors by remember { mutableStateOf(listOf<SensorDB>()) }
     val planViewModel = scanViewModel.planViewModel
     val plans = planViewModel.plans.observeAsState()
     val points = planViewModel.filteredPoints.distinctUntilChanged().observeAsState(listOf())
     var addPoint by remember { mutableStateOf<SensorDB?>(null) }
+
+    LaunchedEffect(addPoint) {
+        unplacedSensors = MainActivity.db.sensorDao().getSensorsUnplacedByStructure(scanViewModel.structureId ?: -1)
+    }
 
     Column(
         verticalArrangement = Arrangement.spacedBy(5.dp, Alignment.Top),
@@ -81,8 +93,9 @@ fun PlansView(scanViewModel: ScanViewModel) {
             val image = planViewModel.image.observeAsState(planViewModel.defaultImage)
             Plan(
                 image = image.value,
-                points = if (addPoint == null) points.value else points.value.plus(addPoint!!),
-                addPoint = { x, y -> addPoint = SensorDB.point(x, y) },
+                points = { points.value },
+                temporaryPoint = addPoint,
+                addPoint = { x, y -> addPoint = SensorDB.point(scanViewModel, x, y) },
                 deletePoint = { /* TODO enable to remove points */ }
             )
 
@@ -94,8 +107,13 @@ fun PlansView(scanViewModel: ScanViewModel) {
 
             if (addPoint != null) {
                 AddPointPane(
-                    listOf("Capteur PA", "Capteur P8S", "Capteur P8N", "Capteur A", "Sensor B"),
-                    { addPoint = null },
+                    unplacedSensors,
+                    { sensor ->
+                        addPoint?.let {
+                            planViewModel.placeSensor(sensor, it.plan, it.x, it.y)
+                            addPoint = null
+                        }
+                    },
                     { addPoint = null }
                 )
             } else {
@@ -107,7 +125,16 @@ fun PlansView(scanViewModel: ScanViewModel) {
     }
 }
 
-private fun SensorDB.Companion.point(x: Double, y: Double): SensorDB {
+/**
+ * Creates a half-filled sensor waiting to be linked with a real
+ * sensor. This one only contains position and plan.
+ * @param scanViewModel access to the currently selected plan
+ * @param x the x coordinate of the point in the image
+ * @param y the y coordinate of the point in the image
+ * @return the sensor or null if no plan is selected
+ */
+private fun SensorDB.Companion.point(scanViewModel: ScanViewModel, x: Double, y: Double): SensorDB? {
+    val selectedPlan = scanViewModel.planViewModel.selected.value ?: return null
     return SensorDB(
         sensorId = "",
         controlChip = "",
@@ -117,10 +144,10 @@ private fun SensorDB.Companion.point(x: Double, y: Double): SensorDB {
         "",
         installationDate = null,
         state = SensorState.UNKNOWN.name,
-        plan = 0, // TODO
+        plan = selectedPlan.plan.id,
         x = x,
         y = y,
-        structureId = 0 // TODO
+        structureId = selectedPlan.plan.structureId
     )
 }
 
@@ -218,5 +245,39 @@ private fun PlanItem(name: String, selected: Boolean, onClick: () -> Unit) {
                 color = Black
             )
         )
+    }
+}
+
+/**
+ * Component that prompts the user to select a point to place on the
+ * plan.
+ * @param sensors the list of available sensors
+ * @param onSubmit the action to run when a sensor is selected
+ * @param onCancel the action to run when the cancel button is pressed
+ */
+@Composable
+fun AddPointPane(
+    sensors: List<SensorDB>,
+    onSubmit: (SensorDB) -> Unit,
+    onCancel: () -> Unit
+) {
+    var search by remember { mutableStateOf("") }
+    val options = remember { sensors.associateBy { it.name } }
+    val valid = options[search]
+    Column(
+        Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(15.dp, Alignment.CenterVertically),
+        horizontalAlignment = Alignment.Start
+    ) {
+        Title("Nouveau point", false) {
+            Button(R.drawable.x, "Cancel") { onCancel() }
+            Box (Modifier.alpha(if (valid != null) 1f else .25f)) {
+                Button(R.drawable.check, "Save", White, Black) {
+                    valid?.let { onSubmit(it) }
+                }
+            }
+            // Button(R.drawable.trash, "Save", Red, Red.copy(alpha = 0.1f))
+        }
+        ComboBox("Capteur", options.keys, search, { search = it }, if (valid != null) Black else Red)
     }
 }

--- a/Android/app/src/main/java/fr/uge/structsure/scanPage/presentation/components/ScanWeather.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/scanPage/presentation/components/ScanWeather.kt
@@ -77,7 +77,7 @@ fun ScanWeather(viewModel: ScanViewModel, scrollState: ScrollState) {
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
-                text = "Viaduc de Sylans",
+                text = viewModel.structure?.name?:"Ouvrage",
                 style = MaterialTheme.typography.titleLarge
             )
 

--- a/Android/app/src/main/java/fr/uge/structsure/scanPage/presentation/components/SensorsList.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/scanPage/presentation/components/SensorsList.kt
@@ -150,7 +150,7 @@ private fun SortFilter(
         InputSearch(
             label = "Rechercher",
             value = search.value,
-            placeholder = "Rechercher...",
+            placeholder = "Rechercher",
             onChange = {
                 search.value = it
             }

--- a/Android/app/src/main/java/fr/uge/structsure/structuresPage/data/Sensor.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/structuresPage/data/Sensor.kt
@@ -31,4 +31,6 @@ data class SensorDB(
     val x: Double,
     val y: Double,
     val structureId: Long
-)
+) {
+    companion object
+}

--- a/Android/app/src/main/java/fr/uge/structsure/structuresPage/data/Sensor.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/structuresPage/data/Sensor.kt
@@ -2,9 +2,8 @@ package fr.uge.structsure.structuresPage.data
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import fr.uge.structsure.scanPage.presentation.components.SensorState
 
-
-data class SensorId(val controlChip: String, val measureChip: String)
 
 data class Sensor(
     val controlChip: String,
@@ -26,11 +25,13 @@ data class SensorDB(
     val name: String,
     val note: String?,
     val installationDate: String?,
-    val state: String,
+    private val _state: String?,
     val plan: Long?,
     val x: Double,
     val y: Double,
     val structureId: Long
 ) {
+    val state: String
+        get() = _state ?: SensorState.UNKNOWN.name
     companion object
 }

--- a/Android/app/src/main/java/fr/uge/structsure/structuresPage/data/SensorDao.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/structuresPage/data/SensorDao.kt
@@ -12,15 +12,21 @@ interface SensorDao {
     @Query("DELETE FROM sensors WHERE structureId = :structureId")
     fun deleteSensorsByStructureId(structureId: Long)
 
-    @Query("SELECT * from sensors as s WHERE s.structureId = :id")
+    @Query("SELECT * FROM sensors AS s WHERE s.structureId = :id")
     suspend fun getAllSensors(id: Long): List<SensorDB>
 
     @Query("SELECT * FROM sensors WHERE sensorId = :id")
     suspend fun getSensor(id: String): SensorDB?
     
-    @Query("SELECT * from sensors as s WHERE s.`plan` = :plan")
+    @Query("SELECT * FROM sensors AS s WHERE s.`plan` = :plan")
     fun getAllSensorsByPlan(plan: Long): List<SensorDB>
 
     @Query("UPDATE sensors SET note = :note WHERE sensorId = :sensorId")
     fun updateNote(sensorId: String, note: String)
+    
+    @Query("SELECT * FROM sensors WHERE structureId = :structureId AND `plan` IS NULL")
+    fun getSensorsUnplacedByStructure(structureId: Long): List<SensorDB>
+
+    @Query("UPDATE sensors SET `plan` = :plan, x = :x, y = :y WHERE sensorId = :id")
+    fun placeSensor(id: String, plan: Long?, x: Double, y: Double)
 }

--- a/Android/app/src/main/java/fr/uge/structsure/structuresPage/data/SensorDao.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/structuresPage/data/SensorDao.kt
@@ -12,8 +12,13 @@ interface SensorDao {
     @Query("DELETE FROM sensors WHERE structureId = :structureId")
     fun deleteSensorsByStructureId(structureId: Long)
 
-    @Query("SELECT * FROM sensors AS s WHERE s.structureId = :id")
-    suspend fun getAllSensors(id: Long): List<SensorDB>
+    @Query("""
+        SELECT s.sensorId, s.controlChip, s.measureChip, s.name, s.note, s.installationDate, r.state, s.`plan`, s.x, s.y, s.structureId
+        FROM sensors AS s
+        LEFT JOIN resultSensor AS r ON s.controlChip = r.controlChip
+        WHERE s.structureId = :id
+    """)
+    suspend fun getAllSensorsWithResults(id: Long): List<SensorDB>
 
     @Query("SELECT * FROM sensors WHERE sensorId = :id")
     suspend fun getSensor(id: String): SensorDB?
@@ -29,4 +34,7 @@ interface SensorDao {
 
     @Query("UPDATE sensors SET `plan` = :plan, x = :x, y = :y WHERE sensorId = :id")
     fun placeSensor(id: String, plan: Long?, x: Double, y: Double)
+
+    @Query("SELECT _state FROM sensors WHERE sensorId = :sensorId")
+    fun getSensorState(sensorId: String): String
 }

--- a/Android/app/src/main/java/fr/uge/structsure/structuresPage/data/StructureDao.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/structuresPage/data/StructureDao.kt
@@ -20,5 +20,5 @@ interface StructureDao {
     fun getAllStructures(): List<StructureData>
 
     @Query("SELECT * FROM structure WHERE id = :id")
-    suspend fun getStructureById(id: Long): StructureData?
+    fun getStructureById(id: Long): StructureData?
 }

--- a/Android/app/src/main/java/fr/uge/structsure/structuresPage/domain/StructureViewModel.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/structuresPage/domain/StructureViewModel.kt
@@ -86,6 +86,7 @@ class StructureViewModel(private val structureRepository: StructureRepository,
         viewModelScope.launch {
             structureData.state.value = StructureStates.DOWNLOADING
             val success = structureRepository.downloadStructure(structureData.raw, context)
+            delay(1000) // FIXME For some reason, sensors are not fully download here...
             structureData.state.value = if (success) StructureStates.AVAILABLE else StructureStates.ONLINE
         }
     }
@@ -176,18 +177,6 @@ class StructureViewModel(private val structureRepository: StructureRepository,
             } finally {
                 this@StructureViewModel.uploadInProgress.postValue(false)
             }
-        }
-    }
-
-    /**
-     * Clear the local data of the structure with the given id.
-     */
-    private suspend fun cleanupLocalData(structureId: Long) {
-        try {
-            structureRepository.deleteStructure(structureId, context)
-            getAllStructures()
-        } catch (e: Exception) {
-            Log.e("StructureVM", "Error cleaning up local data", e)
         }
     }
 }

--- a/Android/app/src/main/java/fr/uge/structsure/structuresPage/presentation/components/SearchBar.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/structuresPage/presentation/components/SearchBar.kt
@@ -10,7 +10,7 @@ fun SearchBar(input: MutableState<String>) {
     Row {
         InputSearch(
             value = input.value,
-            placeholder = "Rechercher...",
+            placeholder = "Rechercher",
             onChange = {
                 input.value = it
             }

--- a/Android/app/src/main/res/drawable/trash.xml
+++ b/Android/app/src/main/res/drawable/trash.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="20"
+    android:viewportHeight="20">
+  <path
+      android:pathData="M2.5,5H17.5M15.833,5V16.667C15.833,17.5 15,18.333 14.167,18.333H5.833C5,18.333 4.167,17.5 4.167,16.667V5M6.667,5V3.333C6.667,2.5 7.5,1.667 8.333,1.667H11.667C12.5,1.667 13.333,2.5 13.333,3.333V5M8.333,9.167V14.167M11.667,9.167V14.167"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#F13327"
+      android:strokeLineCap="round"/>
+</vector>

--- a/Backend/src/main/java/fr/uge/structsure/dto/scan/AndroidSensorEditDTO.java
+++ b/Backend/src/main/java/fr/uge/structsure/dto/scan/AndroidSensorEditDTO.java
@@ -7,5 +7,8 @@ package fr.uge.structsure.dto.scan;
  */
 public record AndroidSensorEditDTO(
     String sensorId,
-    String note
+    String note,
+    Long plan,
+    Integer x,
+    Integer y
 ) {}


### PR DESCRIPTION
Cliquer sur un espace vide pour placer un capteur sur un plan lorsqu'un scan est lancé. On peut alors choisir un capteur parmi ceux qui ne sont pas encore placés. A la fin du scan, ces changements sont envoyés au serveur et sauvegardés.