### PR TITLE
#227 send sensor state to android

### DIFF
--- a/Android/app/src/main/java/fr/uge/structsure/structuresPage/data/Sensor.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/structuresPage/data/Sensor.kt
@@ -7,10 +7,12 @@ import androidx.room.PrimaryKey
 data class SensorId(val controlChip: String, val measureChip: String)
 
 data class Sensor(
-    val sensorId: SensorId,
+    val controlChip: String,
+    val measureChip: String,
     val name: String,
     val note: String,
     val installationDate: String,
+    val state: String,
     val plan: Long?,
     val x: Double,
     val y: Double

--- a/Android/app/src/main/java/fr/uge/structsure/structuresPage/data/StructureRepository.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/structuresPage/data/StructureRepository.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.database.sqlite.SQLiteException
 import android.util.Log
 import androidx.lifecycle.ViewModel
-import fr.uge.structsure.MainActivity
 import fr.uge.structsure.MainActivity.Companion.db
 import fr.uge.structsure.retrofit.RetrofitInstance
 import fr.uge.structsure.utils.FileUtils
@@ -21,11 +20,11 @@ class StructureRepository : ViewModel() {
         private const val TAG = "StructureRepository"
     }
 
-    private val structureDao = MainActivity.db.structureDao()
-    private val planDao = MainActivity.db.planDao()
-    private val sensorDao = MainActivity.db.sensorDao()
-    private val resultDao = MainActivity.db.resultDao()
-    private val scanDao = MainActivity.db.scanDao()
+    private val structureDao = db.structureDao()
+    private val planDao = db.planDao()
+    private val sensorDao = db.sensorDao()
+    private val resultDao = db.resultDao()
+    private val scanDao = db.scanDao()
 
     private fun getApiInterface() = RetrofitInstance.structureApi
 
@@ -116,13 +115,13 @@ class StructureRepository : ViewModel() {
                 result.sensors.forEach { sensor ->
                     sensorDao.upsertSensor(
                         SensorDB(
-                            "${sensor.sensorId.controlChip}-${sensor.sensorId.measureChip}",
-                            sensor.sensorId.controlChip,
-                            sensor.sensorId.measureChip,
+                            "${sensor.controlChip}-${sensor.measureChip}",
+                            sensor.controlChip,
+                            sensor.measureChip,
                             sensor.name,
                             sensor.note,
                             sensor.installationDate,
-                            "Non scanné",
+                            sensor.state,
                             sensor.plan,
                             sensor.x,
                             sensor.y,

--- a/Backend/src/main/java/fr/uge/structsure/controllers/StructureController.java
+++ b/Backend/src/main/java/fr/uge/structsure/controllers/StructureController.java
@@ -185,7 +185,7 @@ public class StructureController {
      * @return List of structures
      */
     @GetMapping(value = "", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<?> getAllStructure(AllStructureRequestDTO allStructureRequestDTO){
+    public ResponseEntity<?> getAllStructure(AllStructureRequestDTO allStructureRequestDTO) {
         try {
             return ResponseEntity.status(200).body(structureService.getAllStructure(allStructureRequestDTO));
         } catch (TraitementException e) {
@@ -194,17 +194,13 @@ public class StructureController {
     }
 
     @GetMapping(value = "/android/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public StructureResponseDTO getStructureById(@PathVariable("id") Long id) {
-        var structure = structureService.getStructureById(id);
-        return new StructureResponseDTO(
-            structure.id(),
-            structure.name(),
-            structure.note(),
-            structure.plans().stream().filter(plan -> !plan.isArchived()).toList(),
-            structure.sensors().stream().filter(sensor -> !sensor.isArchived()).toList()
-        );
+    public ResponseEntity<?> getStructureById(@PathVariable("id") Long id) {
+        try {
+            return ResponseEntity.status(200).body(structureService.downloadStructureAndroid(id));
+        } catch (TraitementException e) {
+            return e.toResponseEntity();
+        }
     }
-
 
     /**
      * Returns the structure details with the specified id

--- a/Backend/src/main/java/fr/uge/structsure/controllers/StructureController.java
+++ b/Backend/src/main/java/fr/uge/structsure/controllers/StructureController.java
@@ -5,7 +5,6 @@ import fr.uge.structsure.dto.structure.AddStructureRequestDTO;
 import fr.uge.structsure.dto.structure.AllStructureRequestDTO;
 import fr.uge.structsure.dto.structure.StructureResponseDTO;
 import fr.uge.structsure.exceptions.TraitementException;
-import fr.uge.structsure.repositories.StructureRepositoryCriteriaQuery;
 import fr.uge.structsure.services.PlanService;
 import fr.uge.structsure.services.StructureService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,7 +15,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -197,7 +195,14 @@ public class StructureController {
 
     @GetMapping(value = "/android/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
     public StructureResponseDTO getStructureById(@PathVariable("id") Long id) {
-        return structureService.getStructureById(id);
+        var structure = structureService.getStructureById(id);
+        return new StructureResponseDTO(
+            structure.id(),
+            structure.name(),
+            structure.note(),
+            structure.plans().stream().filter(plan -> !plan.isArchived()).toList(),
+            structure.sensors().stream().filter(sensor -> !sensor.isArchived()).toList()
+        );
     }
 
 

--- a/Backend/src/main/java/fr/uge/structsure/dto/plan/PlanDTO.java
+++ b/Backend/src/main/java/fr/uge/structsure/dto/plan/PlanDTO.java
@@ -1,0 +1,20 @@
+package fr.uge.structsure.dto.plan;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import fr.uge.structsure.entities.Plan;
+
+@JsonSerialize
+public record PlanDTO(
+    long id,
+    String name,
+    String imageUrl,
+    String section
+) {
+    /**
+     * Alias to create a new DTO from a Plan object
+     * @param plan the plan to get the data from
+     */
+    public PlanDTO(Plan plan) {
+        this(plan.getId(), plan.getName(), plan.getImageUrl(), plan.getSection());
+    }
+}

--- a/Backend/src/main/java/fr/uge/structsure/dto/sensors/SensorDTO.java
+++ b/Backend/src/main/java/fr/uge/structsure/dto/sensors/SensorDTO.java
@@ -9,12 +9,13 @@ import java.time.LocalDate;
 /**
  * The sensor dto
  * @param controlChip the control chip id
- * @param measureChip the measur chip id
+ * @param measureChip the measure chip id
  * @param name the name of the sensor
  * @param note the note of the sensor
  * @param state the state of the sensor
  * @param archived true if the sensor is archived and false if not
  * @param installationDate the installation date of the sensor
+ * @param plan the id of the plan where the sensor is placed
  * @param x the position x of the sensor
  * @param y the position y of the sensor
  */
@@ -27,54 +28,57 @@ public record SensorDTO(
         State state,
         Boolean archived,
         LocalDate installationDate,
+        Long plan,
         Integer x,
         Integer y
 ) {
 
     /**
-     * The sensor dto constructor from state as Integer type
+     * The sensor dto constructor from state as Integer type used in
+     * {@link fr.uge.structsure.repositories.SensorRepositoryCriteriaQuery}
      * @param controlChip the control chip id
-     * @param measureChip the measur chip id
+     * @param measureChip the measure chip id
      * @param name the name of the sensor
      * @param note the note of the sensor
      * @param state the state of the sensor (Integer type)
      * @param archived true if the sensor is archived and false if not
      * @param installationDate the installation date of the sensor
+     * @param plan the plan where the sensor is placed
      * @param x the position x of the sensor
      * @param y the position y of the sensor
      */
     public SensorDTO(
-            String controlChip,
-            String measureChip,
-            String name,
-            String note,
-            Integer state,
-            boolean archived,
-            LocalDate installationDate,
-            Integer x,
-            Integer y
+        String controlChip,
+        String measureChip,
+        String name,
+        String note,
+        Integer state,
+        boolean archived,
+        LocalDate installationDate,
+        Long plan,
+        Integer x,
+        Integer y
     ) {
 
-        this(controlChip, measureChip, name, note, State.values()[state], archived, installationDate, x, y);
+        this(controlChip, measureChip, name, note, State.values()[state], archived, installationDate, plan, x, y);
     }
 
     /**
      * Returns the dto from the entity and the state of the sensor
      * @param sensor the sensor entity
      * @param state the state of the sensor
-     * @return the dto for the sensor
      */
-    public static SensorDTO fromEntityAndState(Sensor sensor, State state) {
-        return new SensorDTO(
-                sensor.getSensorId().getControlChip(),
-                sensor.getSensorId().getMeasureChip(),
-                sensor.getName(),
-                sensor.getNote(),
-                state,
-                sensor.isArchived(),
-                sensor.getInstallationDate(),
-                sensor.getX(),
-                sensor.getY()
-        );
+    public SensorDTO(Sensor sensor, State state) {
+        this(
+            sensor.getSensorId().getControlChip(),
+            sensor.getSensorId().getMeasureChip(),
+            sensor.getName(),
+            sensor.getNote(),
+            state,
+            sensor.isArchived(),
+            sensor.getInstallationDate(),
+            sensor.getPlan().getId(),
+            sensor.getX(),
+            sensor.getY());
     }
 }

--- a/Backend/src/main/java/fr/uge/structsure/dto/sensors/SensorDTO.java
+++ b/Backend/src/main/java/fr/uge/structsure/dto/sensors/SensorDTO.java
@@ -71,7 +71,7 @@ public record SensorDTO(
                 sensor.getName(),
                 sensor.getNote(),
                 state,
-                sensor.getArchived(),
+                sensor.isArchived(),
                 sensor.getInstallationDate(),
                 sensor.getX(),
                 sensor.getY()

--- a/Backend/src/main/java/fr/uge/structsure/dto/structure/StructureDetailsResponseDTO.java
+++ b/Backend/src/main/java/fr/uge/structsure/dto/structure/StructureDetailsResponseDTO.java
@@ -74,7 +74,7 @@ public record StructureDetailsResponseDTO(long id, String name, String note,
         }
 
         public static Plan fromPlanEntity(fr.uge.structsure.entities.Plan plan) {
-            return new Plan(plan.getId(), plan.getName(), plan.getSection(), plan.getArchived());
+            return new Plan(plan.getId(), plan.getName(), plan.getSection(), plan.isArchived());
         }
     }
 

--- a/Backend/src/main/java/fr/uge/structsure/dto/structure/StructureResponseDTO.java
+++ b/Backend/src/main/java/fr/uge/structsure/dto/structure/StructureResponseDTO.java
@@ -1,7 +1,8 @@
 package fr.uge.structsure.dto.structure;
 
-import fr.uge.structsure.entities.Plan;
-import fr.uge.structsure.entities.Sensor;
+import fr.uge.structsure.dto.plan.PlanDTO;
+import fr.uge.structsure.dto.sensors.SensorDTO;
+import fr.uge.structsure.entities.Structure;
 
 import java.util.List;
 
@@ -9,6 +10,17 @@ public record StructureResponseDTO(
     Long id,
     String name,
     String note,
-    List<Plan> plans,
-    List<Sensor> sensors
-) { }
+    List<PlanDTO> plans,
+    List<SensorDTO> sensors
+) {
+    /**
+     * Alternative constructor that directly takes a structure and
+     * fill internal values automatically.
+     * @param structure the structure to get id, name and note from
+     * @param plans the plans to attach in the response
+     * @param sensors the sensors to attach in the response
+     */
+    public StructureResponseDTO(Structure structure, List<PlanDTO> plans, List<SensorDTO> sensors) {
+        this(structure.getId(), structure.getName(), structure.getNote(), plans, sensors);
+    }
+}

--- a/Backend/src/main/java/fr/uge/structsure/entities/Plan.java
+++ b/Backend/src/main/java/fr/uge/structsure/entities/Plan.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.*;
 
-import java.io.File;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -103,7 +102,7 @@ public class Plan {
      * Checks if the plan is archived
      * @return true if paln archived and false if not
      */
-    public boolean getArchived() {
+    public boolean isArchived() {
         return archived;
     }
 

--- a/Backend/src/main/java/fr/uge/structsure/entities/Sensor.java
+++ b/Backend/src/main/java/fr/uge/structsure/entities/Sensor.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import jakarta.persistence.*;
 import org.hibernate.validator.internal.util.stereotypes.Lazy;
 
-import java.time.LocalDateTime;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.util.*;
@@ -203,7 +202,7 @@ public class Sensor {
         this.y = y;
     }
 
-    public Boolean getArchived() {
+    public Boolean isArchived() {
         return archived;
     }
 

--- a/Backend/src/main/java/fr/uge/structsure/repositories/PlanRepository.java
+++ b/Backend/src/main/java/fr/uge/structsure/repositories/PlanRepository.java
@@ -14,13 +14,6 @@ import java.util.Optional;
 public interface PlanRepository extends JpaRepository<Plan, Long> {
 
     /**
-     * Counts the number of plan in the structure
-     * @param structure the structure
-     * @return the number
-     */
-    long countByStructure(Structure structure);
-
-    /**
      * Will find the plan by its id, and also that is present in the structure
      * @param structure the structure
      * @param planId the plan id
@@ -34,6 +27,14 @@ public interface PlanRepository extends JpaRepository<Plan, Long> {
      * @return the list of plans
      */
     List<Plan> findByStructure(Structure structure);
+
+    /**
+     * Finds all the plan linked to the given structure that are not
+     * archived.
+     * @param structure the structure to get plans from
+     * @return all the not archived structure's plan
+     */
+    List<Plan> findByStructureAndArchivedFalse(Structure structure);
 
     @Query("SELECT CASE WHEN COUNT(*) > 0 THEN true ELSE false END FROM Plan p WHERE p.imageUrl = :url")
     boolean planFileAlreadyExists(String url);

--- a/Backend/src/main/java/fr/uge/structsure/repositories/SensorRepository.java
+++ b/Backend/src/main/java/fr/uge/structsure/repositories/SensorRepository.java
@@ -73,41 +73,6 @@ SensorRepository extends JpaRepository<Sensor, Long> {
     List<Sensor> findByStructure(Structure structure);
 
     /**
-     * Counts the number of sensors in the structure
-     * @param structure the structure
-     * @return the number of sensors
-     */
-    long countByStructure(Structure structure);
-
-    /**
-     * Checks if there is a sensor with NOK state
-     * @param structure the structure
-     * @return true if yes and false if not
-     */
-    @Query("""
-    SELECT COUNT(sensor.sensorId) > 0
-    FROM Sensor sensor
-    JOIN Result result ON result.sensor = sensor
-    WHERE sensor.structure = :structure
-    AND result.state = fr.uge.structsure.entities.State.NOK
-    """)
-    boolean existsSensorWithNokState(Structure structure);
-
-    /**
-     * Checks if there is a sensor with DEFECTIVE state
-     * @param structure the structure
-     * @return true if yes and false if not
-     */
-    @Query("""
-        SELECT COUNT(sensor.sensorId) > 0
-        FROM Sensor sensor
-        JOIN Result result ON result.sensor = sensor
-        WHERE sensor.structure = :structure
-        AND result.state = fr.uge.structsure.entities.State.DEFECTIVE
-    """)
-    boolean existsSensorWithDefectiveState(Structure structure);
-
-    /**
      * Finds the sensor by chip ids
      * @param controlChip the control chip id
      * @param measureChip the measure chip id
@@ -122,6 +87,7 @@ SensorRepository extends JpaRepository<Sensor, Long> {
      * @return List<Sensor> list of the sensors
      */
     List<Sensor> findByPlan(Plan plan);
+
     /**
      * Will find a sensor by its id
      * @param sensorId the id of the sensor

--- a/Backend/src/main/java/fr/uge/structsure/repositories/SensorRepositoryCriteriaQuery.java
+++ b/Backend/src/main/java/fr/uge/structsure/repositories/SensorRepositoryCriteriaQuery.java
@@ -13,7 +13,6 @@ import jakarta.persistence.criteria.*;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
@@ -62,6 +61,7 @@ public class SensorRepositoryCriteriaQuery {
                 state,
                 sensor.get("archived"),
                 sensor.get("installationDate"),
+                sensor.get("plan").get("id"),
                 sensor.get("x"),
                 sensor.get("y")
         ));

--- a/Backend/src/main/java/fr/uge/structsure/services/PlanService.java
+++ b/Backend/src/main/java/fr/uge/structsure/services/PlanService.java
@@ -162,7 +162,7 @@ public class PlanService {
      */
     private void checkState(Plan plan, Structure structure) throws TraitementException {
         checkState(structure);
-        if (plan.getArchived()) {
+        if (plan.isArchived()) {
             throw new TraitementException(Error.PLAN_IS_ARCHIVED);
         }
     }

--- a/Backend/src/main/java/fr/uge/structsure/services/PlanService.java
+++ b/Backend/src/main/java/fr/uge/structsure/services/PlanService.java
@@ -10,6 +10,7 @@ import fr.uge.structsure.exceptions.TraitementException;
 import fr.uge.structsure.entities.Structure;
 import fr.uge.structsure.exceptions.Error;
 import fr.uge.structsure.repositories.PlanRepository;
+import fr.uge.structsure.repositories.SensorRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,6 +40,7 @@ import java.util.Optional;
 public class PlanService {
     private static final Logger LOGGER = LoggerFactory.getLogger(PlanService.class);
     private final PlanRepository planRepository;
+    private final SensorRepository sensorRepository;
     private final StructureService structureService;
     private final SensorService sensorService;
 
@@ -53,12 +55,15 @@ public class PlanService {
     /**
      * Constructor
      * @param planRepository The plan repo
+     * @param sensorRepository The sensor repo
      * @param structureService The structure service
      * @param sensorService The sensor service
      */
     @Autowired
-    public PlanService(PlanRepository planRepository, StructureService structureService, SensorService sensorService) {
+    public PlanService(PlanRepository planRepository, SensorRepository sensorRepository,
+           StructureService structureService, SensorService sensorService) {
         this.planRepository = planRepository;
+        this.sensorRepository = sensorRepository;
         this.structureService = structureService;
         this.sensorService = sensorService;
     }
@@ -503,9 +508,7 @@ public class PlanService {
         Objects.requireNonNull(controlChip);
         Objects.requireNonNull(measureChip);
         var plan = sensorService.getPlanFromSensor(controlChip, measureChip);
-        if(structureService.getStructureById(structureId)
-                .sensors()
-                .stream()
+        if(sensorRepository.findByStructureId(structureId).stream()
                 .noneMatch(sensor -> sensor.getSensorId().equals(new SensorId(controlChip, measureChip)))){
             throw new TraitementException(Error.SENSOR_NOT_FOUND);
         }

--- a/Backend/src/main/java/fr/uge/structsure/services/SensorService.java
+++ b/Backend/src/main/java/fr/uge/structsure/services/SensorService.java
@@ -91,7 +91,7 @@ public class SensorService {
         var structure = structureRepository.findById(structureId).orElseThrow(() -> new TraitementException(Error.STRUCTURE_ID_NOT_FOUND));
         var plan = planRepository.findByStructureAndId(structure, planId).orElseThrow(() -> new TraitementException(Error.PLAN_NOT_FOUND));
         var sensors = sensorRepository.findByPlan(plan);
-        return sensors.stream().map(sensor -> SensorDTO.fromEntityAndState(sensor, getSensorState(sensor))).toList();
+        return sensors.stream().map(sensor -> new SensorDTO(sensor, getSensorState(sensor))).toList();
     }
 
     /**

--- a/Backend/src/main/java/fr/uge/structsure/services/StructureService.java
+++ b/Backend/src/main/java/fr/uge/structsure/services/StructureService.java
@@ -176,8 +176,8 @@ public class StructureService {
     public StructureResponseDTO getStructureById(Long id) {
         Objects.requireNonNull(id);
         var structureOptional = structureRepository.findById(id);
-        if (structureOptional.isEmpty()){
-        throw new IllegalArgumentException("Structure n'existe pas");
+        if (structureOptional.isEmpty()) {
+            throw new IllegalArgumentException("Structure n'existe pas");
         }
         var structure = structureOptional.get();
         var plans = planRepository.findByStructure(structure);

--- a/Backend/src/main/java/fr/uge/structsure/utils/sort/SortByStateStrategy.java
+++ b/Backend/src/main/java/fr/uge/structsure/utils/sort/SortByStateStrategy.java
@@ -7,6 +7,6 @@ import java.util.Comparator;
 public class SortByStateStrategy implements SensorSortStrategy {
     @Override
     public Comparator<Sensor> getComparator() {
-        return Comparator.comparing(Sensor::getArchived);
+        return Comparator.comparing(Sensor::isArchived);
     }
 }


### PR DESCRIPTION
Actuellement, l'application android n'a pas connaissance du dernier état d'un capteur. C'est une information qu'elle devrait avoir lorsqu'elle télécharge un ouvrage.
Corrige l'endpoint côté Backend pour que cette information soit transmise.

(J'en ai profité pour empêcher le serveur d'envoyer les plans et capteurs archivés à Android)