### PR TITLE
#321 details capteurs

### DIFF
--- a/Android/app/src/main/java/fr/uge/structsure/components/Containers.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/components/Containers.kt
@@ -84,6 +84,7 @@ fun Title (
 @Composable
 fun PopUp(
     onClose: () -> Unit,
+    header: @Composable () -> Unit = {},
     content: @Composable () -> Unit = {},
 ) {
     val interactionSource by remember { mutableStateOf(MutableInteractionSource()) }
@@ -115,12 +116,22 @@ fun PopUp(
                         // Disable the ripple when clicking
                     }
                     .background(White)
-                    .padding(25.dp)
-                    .clip(RoundedCornerShape(10.dp))
-                    .verticalScroll(scroll),
+                    .padding(25.dp),
                 verticalArrangement = Arrangement.spacedBy(15.dp)
             ) {
-                content.invoke()
+                header.invoke()
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable(interactionSource = remember { MutableInteractionSource() }, indication = null, true) {
+                            // Disable the ripple when clicking
+                        }
+                        .clip(RoundedCornerShape(10.dp))
+                        .verticalScroll(scroll),
+                    verticalArrangement = Arrangement.spacedBy(15.dp)
+                ) {
+                    content.invoke()
+                }
             }
             Spacer( modifier = Modifier.windowInsetsBottomHeight(WindowInsets.ime))
         }

--- a/Android/app/src/main/java/fr/uge/structsure/components/Plan.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/components/Plan.kt
@@ -54,7 +54,8 @@ fun PlanForSensor(
     ) {
         val planNode = point?.plan?.let { planViewModel.plans.value?.findPlanById(it) }
         planNode?.let {
-            Text(getPlanSectionName(it), color = color, style = typography.headlineMedium)
+            val section = getPlanSectionName(it)
+            if (section.isNotBlank()) Text(section, color = color, style = typography.headlineMedium)
         }
         Plan(planImage, { point?.let { listOf(it) } ?: emptyList()})
     }

--- a/Android/app/src/main/java/fr/uge/structsure/scanPage/domain/ChipFinder.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/scanPage/domain/ChipFinder.kt
@@ -19,8 +19,10 @@ object ChipFinder {
 
     /** Clears all scanned chip from the list. */
     fun reset() {
-        entries.clear()
-        chips.clear()
+        synchronized(this) {
+            entries.clear()
+            chips.clear()
+        }
     }
 
     /**

--- a/Android/app/src/main/java/fr/uge/structsure/scanPage/presentation/ScanPage.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/scanPage/presentation/ScanPage.kt
@@ -136,6 +136,7 @@ private fun SensorPopUp(
     onCancel: () -> Unit
 ) {
     var note by remember { mutableStateOf(sensor.note.orEmpty()) }
+    var scanStarted = scanViewModel.isScanStarted()
 
     val currentStateDisplay = getStateDisplayName(
         scanViewModel.sensorsScanned.observeAsState(initial = emptyList()).value
@@ -144,11 +145,16 @@ private fun SensorPopUp(
 
     val lastStateDisplay = getStateDisplayName(scanViewModel.getPreviousState(sensor.sensorId))
 
-    PopUp(onCancel) {
+    PopUp(onCancel, {
         Title(sensor.name, false) {
-            Button(R.drawable.check, "valider", Black, LightGray) { onSubmit(note) }
+            Button(
+                R.drawable.check,
+                "valider",
+                Black,
+                LightGray
+            ) { if (scanStarted) onSubmit(note) else onCancel() }
         }
-
+    }) {
         PlanForSensor(scanViewModel.planViewModel, sensor, Black)
 
         SensorDetails(
@@ -162,7 +168,8 @@ private fun SensorPopUp(
         InputTextArea(
             label = "Note",
             value = note,
-            placeholder = "Aucune note pour le moment"
+            placeholder = "Aucune note pour le moment",
+            enabled = scanStarted
         ) { s -> note = s.take(1000) }
     }
 }
@@ -185,7 +192,7 @@ private fun ScanNotePopUp(
         }
     }
 
-    PopUp(onCancel) {
+    PopUp(onCancel, {
         Title("Note du scan", false) {
             if (scanState != ScanState.NOT_STARTED) {
                 Button(R.drawable.check, "valider", Black, LightGray) {
@@ -199,7 +206,7 @@ private fun ScanNotePopUp(
                 }
             }
         }
-
+    }) {
         Column(
             verticalArrangement = Arrangement.spacedBy(5.dp, Alignment.CenterVertically),
             horizontalAlignment = Alignment.Start,

--- a/Android/app/src/main/java/fr/uge/structsure/scanPage/presentation/components/ScanWeather.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/scanPage/presentation/components/ScanWeather.kt
@@ -143,7 +143,7 @@ private fun StructureNotePopUp(
         }
     }
 
-    PopUp(onCancel) {
+    PopUp(onCancel, {
         Title("Note de l'ouvrage", false) {
             if (scanState != ScanState.NOT_STARTED) {
                 Button(R.drawable.check, "valider", Black, LightGray) {
@@ -157,6 +157,7 @@ private fun StructureNotePopUp(
                 }
             }
         }
+    }) {
 
         Column(
             verticalArrangement = Arrangement.spacedBy(5.dp, Alignment.CenterVertically),

--- a/Android/app/src/main/java/fr/uge/structsure/scanPage/presentation/components/SensorsList.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/scanPage/presentation/components/SensorsList.kt
@@ -312,7 +312,7 @@ fun AddSensorPopUp(scanViewModel: ScanViewModel, onSubmit: (controlChip: String,
 
     ScanTagPopUp(scanViewModel, scanTagVisible, onScanReadSubmit)
 
-    PopUp(onCancel) {
+    PopUp(onCancel, {
         Title("Ajouter un capteur", false) {
             Button(R.drawable.x, "Annuler", Black, LightGray, onCancel)
             Button(R.drawable.check, "Valider", White, Black) {
@@ -323,6 +323,7 @@ fun AddSensorPopUp(scanViewModel: ScanViewModel, onSubmit: (controlChip: String,
                 }
             }
         }
+    }) {
         Column(verticalArrangement = Arrangement.spacedBy(15.dp)) {
             InputText(Modifier, "Nom *", name, "Capteur 42",
                 errorMessage = errors?.nameError
@@ -382,10 +383,11 @@ fun ScanTagPopUp(scanViewModel: ScanViewModel, visible: MutableState<Boolean>, o
     PopUp({
         scanViewModel.toggleDirectChipRead(false)
         visible.value = false
-    }) {
+    }, {
         Title("Lire un tag", false) {
             Button(R.drawable.x, "Annuler", Black, LightGray) { visible.value = false }
         }
+    }) {
         Text("Approchez le tag de l'interrogateur et sélectionnez le dans la liste ci-dessous.\nLes tag trop éloignés sont affichés avec un point d'interrogation.", style = typography.bodyMedium)
         Column(
             verticalArrangement = Arrangement.spacedBy(10.dp)

--- a/Android/app/src/main/java/fr/uge/structsure/structuresPage/presentation/components/ConfirmPopup.kt
+++ b/Android/app/src/main/java/fr/uge/structsure/structuresPage/presentation/components/ConfirmPopup.kt
@@ -23,8 +23,9 @@ import fr.uge.structsure.ui.theme.White
 @Composable
 fun ConfirmPopup(visible: MutableState<Boolean>, structure: String, onSubmit: () -> Unit) {
     if (!visible.value) return
-    PopUp({ visible.value = false }) {
+    PopUp({ visible.value = false }, {
         Title("Supprimer l'ouvrage", false)
+    }) {
         Text("Êtes-vous sûr de vouloir supprimer \"$structure\" ?", style = typography.bodyMedium)
         Text(
             "La suppression effacera les données de l'ouvrage sur votre appareil, mais vous pourrez toujours les télécharger à nouveau depuis le serveur.",


### PR DESCRIPTION
Fix de la modale des détails d'un capteur qui est éditable sans avoir commencé le scan
L'en-tête des popup est fixée en haut pour rester visible mais le contenu est scrollable.
Fix de l'exception suivante:
```log
FATAL EXCEPTION: DefaultDispatcher-worker-2
Process: fr.uge.structsure, PID: 5043
java.util. ConcurrentModificationException
at androidx. compose. runtime. snapshots. StateListIterator. validateModification (SnapshotStateList.kt: 333)
at androidx. compose. runtime. snapshots. StateListIterator. next (SnapshotStateList.kt: 309)
at java. util. List.replaceAll(List. java:440)
at fr.uge.structsure. scanPage. domain. ChipFinder. add(ChipFinder.kt:46)
at fr.uge.structsure. scanPage. domain. ScanViewModel. cs108Scanner$lambda$0(ScanViewModel.kt:45)
at fr.uge.structsure. scanPage. domain. ScanViewModel. $r8$lambda$SbR_enxGuCN_qGv2Qqb01vjbKtM (Unknown Source:0)
at fr.uge.structsure. scanPage. domain. ScanViewModel$$ExternalSyntheticLambda0. invoke (D8$$SyntheticClass:0)
at fr.uge.structsure.bluetooth. cs108. Cs108Scanner$pollRfid$2. invokeSuspend(Cs108Scanner.kt:68)
at kotlin. coroutines. jvm. internal. BaseContinuationImpl. resumeWith (ContinuationImpl. kt: 33)
```
